### PR TITLE
Add render.yaml for static site deployment

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,19 @@
+services:
+  - type: web
+    name: occu-med-portal
+    env: static
+    buildCommand: npm install -g pnpm@latest && pnpm install --no-frozen-lockfile && cd occu-med-portal && pnpm install --no-frozen-lockfile && pnpm run build
+    staticPublishPath: occu-med-portal/dist/public
+    envVars:
+      - key: PORT
+        value: 3000
+      - key: BASE_PATH
+        value: /
+      - key: VITE_SUPABASE_URL
+        sync: false
+      - key: VITE_SUPABASE_ANON_KEY
+        sync: false
+    routes:
+      - type: rewrite
+        source: /*
+        destination: /index.html


### PR DESCRIPTION
- Sets correct build command with --no-frozen-lockfile so pnpm installs occu-med-portal's dependencies (vite etc.) that aren't in the root lockfile
- Publishes from occu-med-portal/dist/public
- Sets PORT=3000 and BASE_PATH=/ required by vite.config.ts at build time
- Marks VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY as manual env vars
- Adds SPA rewrite rule so /admin and /login routes don't 404 on direct load

https://claude.ai/code/session_0172XU7pKZ6HK6CTdQQtC1i5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added deployment configuration to support application hosting and environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->