### PR TITLE
Fix tsconfig paths for Render build

### DIFF
--- a/occu-med-portal/tsconfig.json
+++ b/occu-med-portal/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../tsconfig.base.json",
   "include": ["src/**/*"],
   "exclude": ["node_modules", "build", "dist", "**/*.test.ts"],
   "compilerOptions": {
@@ -16,7 +16,7 @@
   },
   "references": [
     {
-      "path": "../../lib/api-client-react"
+      "path": "../lib/api-client-react"
     }
   ]
 }


### PR DESCRIPTION
Fixes the remaining Render build error after the previous PR was merged.

**Problem:** `occu-med-portal/tsconfig.json` extended `../../tsconfig.base.json` — written for a local folder structure where the portal lived inside `artifacts/occu-med-portal/` (2 levels deep). On GitHub the portal is at the root level (`occu-med-portal/`), so the correct path is `../tsconfig.base.json`.

**Changes:**
- `extends`: `../../tsconfig.base.json` → `../tsconfig.base.json`
- `references path`: `../../lib/api-client-react` → `../lib/api-client-react`

This was causing Vite 7's production build to fail with:
```
failed to resolve "extends":"../../tsconfig.base.json"
```