### PR TITLE
Fix @assets alias path for Render builds

### DIFF
--- a/occu-med-portal/vite.config.ts
+++ b/occu-med-portal/vite.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(import.meta.dirname, "src"),
-      "@assets": path.resolve(import.meta.dirname, "..", "..", "attached_assets"),
+      "@assets": path.resolve(import.meta.dirname, "..", "attached_assets"),
     },
     dedupe: ["react", "react-dom"],
   },

--- a/occu-med-portal/vite.config.ts
+++ b/occu-med-portal/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
+import { existsSync } from "node:fs";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
 const rawPort = process.env.PORT;
@@ -17,6 +18,15 @@ const port = Number(rawPort);
 if (Number.isNaN(port) || port <= 0) {
   throw new Error(`Invalid PORT value: "${rawPort}"`);
 }
+
+const assetCandidates = [
+  path.resolve(import.meta.dirname, "..", "attached_assets"),
+  path.resolve(import.meta.dirname, "..", "..", "attached_assets"),
+];
+
+const attachedAssetsPath =
+  assetCandidates.find((candidate) => existsSync(candidate)) ??
+  assetCandidates[0];
 
 const basePath = process.env.BASE_PATH;
 
@@ -49,7 +59,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(import.meta.dirname, "src"),
-      "@assets": path.resolve(import.meta.dirname, "..", "attached_assets"),
+      "@assets": attachedAssetsPath,
     },
     dedupe: ["react", "react-dom"],
   },


### PR DESCRIPTION
### Motivation
- The Vite `@assets` alias was resolving one directory too high which caused Vite to fail with `ENOENT` when importing the background PNG during production builds on Render.

### Description
- Change the `@assets` alias in `occu-med-portal/vite.config.ts` to `path.resolve(import.meta.dirname, '..', 'attached_assets')` so it points at the repository-local `attached_assets` directory and allows imports like `@assets/...` to resolve.

### Testing
- Ran `cd occu-med-portal && PORT=4173 BASE_PATH=/ pnpm run build` and the build completed successfully, producing the background image in `dist/public/assets`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b9e4c8408326a8987dd024dcb609)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved asset directory detection during the build process to be more flexible in locating project assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->