### PR TITLE
Revamp PortalMap visuals and make @assets alias resilient

### DIFF
--- a/occu-med-portal/src/components/PortalMap.tsx
+++ b/occu-med-portal/src/components/PortalMap.tsx
@@ -1,6 +1,5 @@
 import { motion } from 'framer-motion';
 import { PORTALS } from '../lib/config';
-import bgImage from '@assets/ChatGPT_Image_Apr_19,_2026,_07_56_01_PM_copy_2_1776690199128.png';
 import { useAuth } from '../hooks/useAuth';
 import { Link } from 'wouter';
 import { useEffect, useState } from 'react';
@@ -13,16 +12,22 @@ function checkFirstVisit() {
   return params.get('skipIntro') !== '1' && localStorage.getItem(INTRO_KEY) !== 'true';
 }
 
-// 220 stars distributed across the canvas
-const stars = Array.from({ length: 220 }, (_, i) => ({
+const stars = Array.from({ length: 260 }, (_, i) => ({
   id: i,
   left: Number(((i * 37.3 + (i % 7) * 13.7) % 100).toFixed(2)),
-  top:  Number(((i * 61.7 + (i % 5) * 17.3) % 100).toFixed(2)),
-  size: 0.8 + (i % 5) * 0.45,
-  duration: 2.5 + (i % 9) * 0.55,
-  delay: (i % 17) * 0.19,
-  bright: i % 9 === 0, // every 9th star gets cross-sparkle
+  top: Number(((i * 61.7 + (i % 5) * 17.3) % 100).toFixed(2)),
+  size: 0.7 + (i % 6) * 0.45,
+  duration: 2.8 + (i % 10) * 0.55,
+  delay: (i % 19) * 0.18,
+  bright: i % 9 === 0,
 }));
+
+const nebulae = [
+  { id: 'n1', x: '16%', y: '24%', size: '34vmin', color: 'rgba(83, 199, 255, 0.16)' },
+  { id: 'n2', x: '79%', y: '28%', size: '28vmin', color: 'rgba(129, 114, 255, 0.14)' },
+  { id: 'n3', x: '24%', y: '78%', size: '42vmin', color: 'rgba(48, 220, 208, 0.13)' },
+  { id: 'n4', x: '84%', y: '76%', size: '38vmin', color: 'rgba(255, 107, 64, 0.12)' },
+];
 
 type LogoState = 'hidden' | 'glow' | 'flare' | 'persist';
 
@@ -38,9 +43,9 @@ export default function PortalMap() {
     if (!introActive) return;
 
     const timers = [
-      setTimeout(() => setLogoState('glow'),    950),
-      setTimeout(() => setLogoState('flare'),  1200),
-      setTimeout(() => setLogoState('persist'), 2100),
+      setTimeout(() => setLogoState('glow'), 900),
+      setTimeout(() => setLogoState('flare'), 1300),
+      setTimeout(() => setLogoState('persist'), 2300),
       setTimeout(() => {
         localStorage.setItem(INTRO_KEY, 'true');
         setIntroActive(false);
@@ -56,20 +61,25 @@ export default function PortalMap() {
   };
 
   return (
-    <div className="relative h-screen w-full overflow-hidden bg-black">
+    <div className="relative h-screen w-full overflow-hidden bg-[#04050b]">
+      <div className="absolute inset-0 space-gradient" />
 
-      {/* Background — no extra filters that soften the image */}
-      <img
-        src={bgImage}
-        alt="Occu-Med galaxy portal"
-        className="absolute inset-0 h-full w-full object-cover"
-        style={{ imageRendering: 'auto', transform: 'translateZ(0)' }}
-      />
+      <div className="pointer-events-none absolute inset-0">
+        {nebulae.map((nebula) => (
+          <span
+            key={nebula.id}
+            className="nebula-cloud"
+            style={{
+              left: nebula.x,
+              top: nebula.y,
+              width: nebula.size,
+              height: nebula.size,
+              background: `radial-gradient(circle, ${nebula.color} 0%, rgba(0,0,0,0) 72%)`,
+            }}
+          />
+        ))}
+      </div>
 
-      {/* Vignette */}
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_center,transparent_38%,rgba(0,0,0,0.5)_100%)]" />
-
-      {/* Stars */}
       <div className="pointer-events-none absolute inset-0">
         {stars.map((star) => (
           <div
@@ -77,31 +87,30 @@ export default function PortalMap() {
             className={star.bright ? 'star star-bright' : 'star'}
             style={{
               left: `${star.left}%`,
-              top:  `${star.top}%`,
-              width:  `${star.size}px`,
+              top: `${star.top}%`,
+              width: `${star.size}px`,
               height: `${star.size}px`,
               '--duration': `${star.duration}s`,
-              '--delay':    `${star.delay}s`,
+              '--delay': `${star.delay}s`,
             } as React.CSSProperties}
           />
         ))}
       </div>
 
-      {/* Comet intro — only rendered on first visit */}
       {introActive && (
         <div className="pointer-events-none absolute inset-0 overflow-hidden">
           <div className="comet-head" />
         </div>
       )}
 
-      {/* Center OCCU-MED logo */}
       <div className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center">
-        <div className={`center-logo ${logoState === 'hidden' ? 'logo-hidden' : logoState === 'glow' ? 'logo-glow' : logoState === 'flare' ? 'logo-flare' : 'logo-persist'}`}>
+        <div
+          className={`center-logo ${logoState === 'hidden' ? 'logo-hidden' : logoState === 'glow' ? 'logo-glow' : logoState === 'flare' ? 'logo-flare' : 'logo-persist'}`}
+        >
           OCCU&#8209;MED
         </div>
       </div>
 
-      {/* Top bar */}
       <div className="absolute left-0 top-0 z-50 flex w-full items-center justify-between p-5 md:p-7">
         <motion.div
           initial={{ opacity: 0, y: -16 }}
@@ -133,60 +142,58 @@ export default function PortalMap() {
         </motion.div>
       </div>
 
-      {/* Portal planets */}
       {PORTALS.map((portal, idx) => {
         const hasAccess = permissions.includes(portal.permissionKey);
         const bloomDuration = 3.8 + (idx % 5) * 0.7;
-        const bloomDelay    = (idx * 0.65) % 3.5;
+        const bloomDelay = (idx * 0.65) % 3.5;
 
         return (
           <motion.button
             key={portal.id}
             aria-label={`${portal.label} portal`}
-            className={`group absolute z-20 flex -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full outline-none ${hasAccess ? 'cursor-pointer' : 'cursor-default'}`}
+            className={`group absolute z-20 flex -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full outline-none ${hasAccess ? 'cursor-pointer' : 'cursor-default'} ${hasAccess ? '' : 'opacity-60'}`}
             style={{
-              left:   `${portal.x}%`,
-              top:    `${portal.y}%`,
-              width:  `${portal.size}vmin`,
+              left: `${portal.x}%`,
+              top: `${portal.y}%`,
+              width: `${portal.size}vmin`,
               height: `${portal.size}vmin`,
             }}
             onClick={() => handlePortalClick(portal)}
             whileHover={hasAccess ? { scale: 1.08 } : { scale: 1.01 }}
             whileTap={hasAccess ? { scale: 0.97 } : undefined}
           >
-            {/* Ambient bloom — always pulsing */}
             <span
               className="ambient-bloom absolute rounded-full"
               style={{
-                inset: '-40%',
-                background: `radial-gradient(circle, ${portal.color}2a 0%, ${portal.color}0c 55%, transparent 80%)`,
+                inset: '-42%',
+                background: `radial-gradient(circle, ${portal.color}35 0%, ${portal.color}18 54%, transparent 82%)`,
                 '--bloom-duration': `${bloomDuration}s`,
-                '--bloom-delay':    `${bloomDelay}s`,
+                '--bloom-delay': `${bloomDelay}s`,
               } as React.CSSProperties}
             />
 
-            {/* Static base glow ring */}
             <span
-              className="absolute inset-0 rounded-full opacity-40 blur-lg transition-opacity duration-500 group-hover:opacity-80"
-              style={{ boxShadow: `0 0 32px 10px ${portal.color}` }}
-            />
-
-            {/* Hover bloom burst */}
-            <span
-              className="absolute rounded-full opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+              className="planet-core absolute inset-[8%] rounded-full"
               style={{
-                inset: '-18%',
-                boxShadow: `0 0 55px 14px ${portal.color}90, inset 0 0 28px ${portal.color}55`,
+                background: `radial-gradient(circle at 30% 28%, #ffffffbb 0%, ${portal.color}cc 34%, ${portal.color}88 62%, #07090f 100%)`,
+                boxShadow: `inset 0 -16px 24px rgba(0,0,0,0.42), inset 10px 10px 20px rgba(255,255,255,0.07), 0 0 35px 12px ${portal.color}33`,
               }}
             />
 
-            {/* Label — invisible by default, floats up on hover */}
             <span
-              className="portal-label pointer-events-none absolute left-1/2 -translate-x-1/2 translate-y-1.5 opacity-0 transition-all duration-500 group-hover:translate-y-0 group-hover:opacity-100"
+              className="absolute inset-[2%] rounded-full opacity-75 transition-opacity duration-500 group-hover:opacity-100"
               style={{
-                bottom: '-2.4em',
-                color: portal.color,
-                textShadow: `0 0 8px ${portal.color}, 0 0 18px ${portal.color}80, 0 0 36px ${portal.color}40`,
+                border: `1px solid ${portal.color}90`,
+                boxShadow: `0 0 22px 4px ${portal.color}88, inset 0 0 30px ${portal.color}50`,
+              }}
+            />
+
+            <span
+              className="portal-label pointer-events-none absolute left-1/2 -translate-x-1/2 translate-y-2 opacity-0 transition-all duration-500 group-hover:translate-y-0 group-hover:opacity-100"
+              style={{
+                bottom: '-2.7em',
+                color: '#eaf3ff',
+                textShadow: `0 0 7px ${portal.color}, 0 0 18px ${portal.color}90, 0 0 34px ${portal.color}40`,
               }}
             >
               {portal.label}
@@ -194,6 +201,8 @@ export default function PortalMap() {
           </motion.button>
         );
       })}
+
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_center,transparent_44%,rgba(0,0,0,0.64)_100%)]" />
     </div>
   );
 }

--- a/occu-med-portal/src/index.css
+++ b/occu-med-portal/src/index.css
@@ -99,11 +99,28 @@
   text-shadow: 0 0 10px currentColor, 0 0 20px currentColor;
 }
 
+.space-gradient {
+  background:
+    radial-gradient(120vmax 100vmax at 50% 50%, #120c2a 0%, #070813 44%, #020308 100%),
+    linear-gradient(165deg, #050611 0%, #090b19 48%, #04050b 100%);
+}
+
+.nebula-cloud {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  filter: blur(22px);
+  opacity: 0.85;
+}
+
+.planet-core {
+  backdrop-filter: saturate(1.2);
+}
+
 /* ── Stars ─────────────────────────────────────────────── */
 
 @keyframes twinkle {
-  0%, 100% { opacity: 0.12; transform: scale(0.85); }
-  50%       { opacity: 0.75; transform: scale(1.05); }
+  0%, 100% { opacity: 0.2; transform: scale(0.86); }
+  50%       { opacity: 0.88; transform: scale(1.08); }
 }
 
 @keyframes sparkle {
@@ -145,8 +162,8 @@
 /* ── Ambient planet bloom ──────────────────────────────── */
 
 @keyframes ambientBloom {
-  0%, 100% { opacity: 0.22; transform: scale(1); }
-  50%       { opacity: 0.52; transform: scale(1.18); }
+  0%, 100% { opacity: 0.28; transform: scale(1); }
+  50%       { opacity: 0.68; transform: scale(1.22); }
 }
 
 .ambient-bloom {
@@ -161,7 +178,7 @@
   0%   { transform: translate(-320px, 0); opacity: 0; }
   6%   { opacity: 1; }
   94%  { opacity: 1; }
-  100% { transform: translate(calc(100vw + 320px), 30vh); opacity: 0; }
+  100% { transform: translate(calc(100vw + 320px), 34vh); opacity: 0; }
 }
 
 .comet-head {
@@ -265,15 +282,20 @@
 /* ── Portal hover labels ───────────────────────────────── */
 
 .portal-label {
-  font-size: 9px;
-  font-weight: 600;
-  letter-spacing: 0.18em;
+  font-size: clamp(9px, 0.86vw, 13px);
+  font-weight: 700;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
   font-family: 'JetBrains Mono', monospace;
   white-space: nowrap;
+  padding: 0.32rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid rgba(235, 244, 255, 0.28);
+  background: linear-gradient(120deg, rgba(12, 16, 34, 0.78), rgba(13, 10, 28, 0.5));
+  backdrop-filter: blur(4px);
   transition: opacity 0.45s ease, transform 0.45s ease, letter-spacing 0.45s ease;
 }
 
 .group:hover .portal-label {
-  letter-spacing: 0.32em;
+  letter-spacing: 0.34em;
 }

--- a/occu-med-portal/vite.config.ts
+++ b/occu-med-portal/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
+import { existsSync } from "node:fs";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
 const rawPort = process.env.PORT;
@@ -17,6 +18,15 @@ const port = Number(rawPort);
 if (Number.isNaN(port) || port <= 0) {
   throw new Error(`Invalid PORT value: "${rawPort}"`);
 }
+
+const assetCandidates = [
+  path.resolve(import.meta.dirname, "..", "attached_assets"),
+  path.resolve(import.meta.dirname, "..", "..", "attached_assets"),
+];
+
+const attachedAssetsPath =
+  assetCandidates.find((candidate) => existsSync(candidate)) ??
+  assetCandidates[0];
 
 const basePath = process.env.BASE_PATH;
 
@@ -49,7 +59,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(import.meta.dirname, "src"),
-      "@assets": path.resolve(import.meta.dirname, "..", "..", "attached_assets"),
+      "@assets": attachedAssetsPath,
     },
     dedupe: ["react", "react-dom"],
   },


### PR DESCRIPTION
### Motivation
- Replace the brittle static background image with a richer procedural space background (nebulae, improved stars and vignette) and refine portal visuals and animations for a more immersive UI.
- Improve first-visit intro timing and star/planet animation parameters for smoother motion and visual balance.
- Make the `@assets` Vite alias robust to different repository layouts so the dev environment finds attached assets reliably.

### Description
- `PortalMap.tsx`: removed the imported background image and added a procedural space background including a `nebulae` array, increased star count and tweaked star properties, adjusted intro/logo timing, and refined portal button visuals (ambient bloom, planet core, hover highlights, label styling and disabled opacity). 
- `index.css`: added `.space-gradient`, `.nebula-cloud`, and `.planet-core` styles, updated `@keyframes` (`twinkle`, `ambientBloom`, `cometFly`) values, and restyled `.portal-label` for responsive sizing, padding, and backdrop blur.
- `vite.config.ts`: added `existsSync` checks and an `attachedAssetsPath` resolver that picks an existing `attached_assets` candidate, and set the `@assets` alias to that resolved path to support multiple repo layouts.

### Testing
- Performed a TypeScript type check with `tsc --noEmit`, which completed successfully.
- Performed a production build with `vite build`, which completed successfully.
- No unit tests were modified; there were no failing automated tests observed during these checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b9e4c8408326a8987dd024dcb609)