### PR TITLE
Add intro video playback before opening portal destinations

### DIFF
--- a/occu-med-portal/src/components/PortalMap.tsx
+++ b/occu-med-portal/src/components/PortalMap.tsx
@@ -2,9 +2,11 @@ import { motion } from 'framer-motion';
 import { PORTALS } from '../lib/config';
 import { useAuth } from '../hooks/useAuth';
 import { Link } from 'wouter';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 const INTRO_KEY = 'occu-med-portal-intro-v2';
+const PORTAL_BG_IMAGE = 'https://images.unsplash.com/photo-1462331940025-496dfbfc7564?auto=format&fit=crop&w=2400&q=80';
+const PORTAL_INTRO_VIDEO_SRC = '/portal-intro.mp4';
 
 function checkFirstVisit() {
   if (typeof window === 'undefined') return false;
@@ -33,11 +35,14 @@ type LogoState = 'hidden' | 'glow' | 'flare' | 'persist';
 
 export default function PortalMap() {
   const { permissions, isLive, isAdmin } = useAuth();
+  const introVideoRef = useRef<HTMLVideoElement | null>(null);
 
   const [introActive, setIntroActive] = useState(checkFirstVisit);
   const [logoState, setLogoState] = useState<LogoState>(() =>
     checkFirstVisit() ? 'hidden' : 'persist'
   );
+  const [pendingPortal, setPendingPortal] = useState<(typeof PORTALS)[0] | null>(null);
+  const [pendingPortalWindow, setPendingPortalWindow] = useState<Window | null>(null);
 
   useEffect(() => {
     if (!introActive) return;
@@ -55,18 +60,52 @@ export default function PortalMap() {
     return () => timers.forEach(clearTimeout);
   }, [introActive]);
 
+  const completePortalNavigation = useCallback(() => {
+    if (!pendingPortal) return;
+    if (pendingPortalWindow && !pendingPortalWindow.closed) {
+      pendingPortalWindow.location.replace(pendingPortal.url);
+    } else {
+      window.open(pendingPortal.url, '_blank', 'noopener,noreferrer');
+    }
+    setPendingPortal(null);
+    setPendingPortalWindow(null);
+  }, [pendingPortal, pendingPortalWindow]);
+
   const handlePortalClick = (portal: (typeof PORTALS)[0]) => {
     if (!permissions.includes(portal.permissionKey)) return;
-    window.open(portal.url, '_blank', 'noopener,noreferrer');
+
+    const nextWindow = window.open('about:blank', '_blank');
+    if (nextWindow) {
+      nextWindow.opener = null;
+    }
+
+    setPendingPortal(portal);
+    setPendingPortalWindow(nextWindow);
+  };
+
+  useEffect(() => {
+    if (!pendingPortal || !introVideoRef.current) return;
+    introVideoRef.current.currentTime = 0;
+    void introVideoRef.current.play().catch(() => {
+      completePortalNavigation();
+    });
+  }, [completePortalNavigation, pendingPortal]);
+
+  const cancelPortalNavigation = () => {
+    if (pendingPortalWindow && !pendingPortalWindow.closed) {
+      pendingPortalWindow.close();
+    }
+    setPendingPortal(null);
+    setPendingPortalWindow(null);
   };
 
   return (
     <div className="relative h-screen w-full overflow-hidden bg-black">
       <img
-        src={bgImage}
+        src={PORTAL_BG_IMAGE}
         alt="Occu-Med galaxy portal"
         className="absolute inset-0 h-full w-full object-cover"
-        style={{ imageRendering: 'high-quality', transform: 'translateZ(0)', filter: 'contrast(1.03) saturate(1.04)' }}
+        style={{ imageRendering: 'auto', transform: 'translateZ(0)', filter: 'contrast(1.03) saturate(1.04)' }}
       />
 
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_center,transparent_35%,rgba(0,0,0,0.48)_100%)]" />
@@ -189,6 +228,37 @@ export default function PortalMap() {
           </motion.button>
         );
       })}
+
+      {pendingPortal && (
+        <div className="absolute inset-0 z-[70] flex items-center justify-center bg-black/88 p-4">
+          <div className="relative w-full max-w-5xl overflow-hidden rounded-xl border border-white/20 bg-black shadow-[0_0_44px_rgba(86,187,255,0.28)]">
+            <video
+              ref={introVideoRef}
+              className="h-full max-h-[80vh] w-full bg-black object-cover"
+              src={PORTAL_INTRO_VIDEO_SRC}
+              onEnded={completePortalNavigation}
+              onError={completePortalNavigation}
+              playsInline
+              controls
+              autoPlay
+            />
+            <button
+              type="button"
+              onClick={completePortalNavigation}
+              className="absolute right-3 top-3 rounded-full border border-white/35 bg-black/65 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.2em] text-white/85 transition hover:border-white/70 hover:text-white"
+            >
+              Skip
+            </button>
+            <button
+              type="button"
+              onClick={cancelPortalNavigation}
+              className="absolute left-3 top-3 rounded-full border border-white/35 bg-black/65 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.2em] text-white/85 transition hover:border-white/70 hover:text-white"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
 
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_center,transparent_44%,rgba(0,0,0,0.64)_100%)]" />
     </div>


### PR DESCRIPTION
### Motivation
- Implement a portal-entry intro so an opening video plays when a user clicks a portal link before navigation to the destination URL.
- Avoid immediate navigation/popups while still allowing navigation to proceed automatically after the video or when the user skips.
- Fix minor type/style issues in the portal component to keep the build/typecheck clean.

### Description
- Updated `occu-med-portal/src/components/PortalMap.tsx` to add a video-overlay flow that is shown after clicking an accessible portal and before completing navigation. 
- Added state and refs (`pendingPortal`, `pendingPortalWindow`, `introVideoRef`) and logic to pre-open an `about:blank` tab to reduce popup blocking and then either `location.replace` that tab or open a new tab after the video ends.
- Added `Skip` and `Close` controls on the overlay where `Skip` immediately completes navigation and `Close` cancels the flow and closes any pre-opened tab.
- Introduced constants `PORTAL_INTRO_VIDEO_SRC` (expects `occu-med-portal/public/portal-intro.mp4`) and `PORTAL_BG_IMAGE`, and adjusted `imageRendering` to a valid value to resolve type errors.

### Testing
- Ran `pnpm --filter @workspace/occu-med-portal typecheck` and the TypeScript check completed successfully.
- No additional automated UI tests were available in this environment, so visual verification should be done in a browser and by placing the intro video at `occu-med-portal/public/portal-intro.mp4`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee953fc4688326b55663ecc60c5fab)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portal navigation now includes an intro video that plays before opening portals, with options to skip or close the flow
  * Users can cancel pending portal navigation at any time
  * Updated portal background imagery and styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->