### PR TITLE
Introduce interactive solar-themed PortalMap with admin video settings and flexible asset aliasing

### DIFF
--- a/occu-med-portal/src/components/PortalMap.tsx
+++ b/occu-med-portal/src/components/PortalMap.tsx
@@ -1,199 +1,242 @@
+import { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
-import { PORTALS } from '../lib/config';
-import bgImage from '@assets/ChatGPT_Image_Apr_19,_2026,_07_56_01_PM_copy_2_1776690199128.png';
-import { useAuth } from '../hooks/useAuth';
-import { Link } from 'wouter';
-import { useEffect, useState } from 'react';
 
-const INTRO_KEY = 'occu-med-portal-intro-v2';
+const STORAGE_KEY = 'occu_med_planet_routes_v1';
 
-function checkFirstVisit() {
-  if (typeof window === 'undefined') return false;
-  const params = new URLSearchParams(window.location.search);
-  return params.get('skipIntro') !== '1' && localStorage.getItem(INTRO_KEY) !== 'true';
+type PlanetId =
+  | 'sun'
+  | 'mercury'
+  | 'venus'
+  | 'earth'
+  | 'mars'
+  | 'jupiter'
+  | 'saturn'
+  | 'uranus'
+  | 'neptune'
+  | 'pluto';
+
+interface PlanetDef {
+  id: PlanetId;
+  label: string;
+  className: string;
+  x: number;
+  y: number;
+  size: number;
+  glow: string;
+  textColor: string;
 }
 
-// 220 stars distributed across the canvas
-const stars = Array.from({ length: 220 }, (_, i) => ({
-  id: i,
-  left: Number(((i * 37.3 + (i % 7) * 13.7) % 100).toFixed(2)),
-  top:  Number(((i * 61.7 + (i % 5) * 17.3) % 100).toFixed(2)),
-  size: 0.8 + (i % 5) * 0.45,
-  duration: 2.5 + (i % 9) * 0.55,
-  delay: (i % 17) * 0.19,
-  bright: i % 9 === 0, // every 9th star gets cross-sparkle
-}));
+interface PlanetSetting {
+  url: string;
+  videoUrl: string;
+}
 
-type LogoState = 'hidden' | 'glow' | 'flare' | 'persist';
+type PlanetSettings = Record<PlanetId, PlanetSetting>;
+
+const PLANETS: PlanetDef[] = [
+  { id: 'sun', label: 'Leadership', className: 'planet-sun', x: 13, y: 50, size: 21, glow: '#ffb339', textColor: '#fff6cf' },
+  { id: 'mercury', label: 'ExamQA', className: 'planet-mercury', x: 34, y: 39, size: 10, glow: '#ff9b76', textColor: '#ffe8d9' },
+  { id: 'venus', label: 'Scheduling', className: 'planet-venus', x: 52, y: 36, size: 11, glow: '#ff6e4f', textColor: '#ffe0cf' },
+  { id: 'earth', label: 'Harvesting', className: 'planet-earth', x: 39, y: 52, size: 11, glow: '#72abff', textColor: '#d7ebff' },
+  { id: 'mars', label: 'SME', className: 'planet-mars', x: 35, y: 66, size: 9, glow: '#ca59ff', textColor: '#f5d8ff' },
+  { id: 'jupiter', label: 'Operations', className: 'planet-jupiter', x: 54, y: 69, size: 19, glow: '#a968ff', textColor: '#ecdcff' },
+  { id: 'saturn', label: 'New', className: 'planet-saturn', x: 68, y: 43, size: 14, glow: '#72a1ff', textColor: '#e1ebff' },
+  { id: 'uranus', label: 'Network', className: 'planet-uranus', x: 81, y: 66, size: 14, glow: '#88f6ff', textColor: '#d9ffff' },
+  { id: 'neptune', label: 'Shared', className: 'planet-neptune', x: 86, y: 45, size: 10, glow: '#5d95ff', textColor: '#d9ebff' },
+  { id: 'pluto', label: 'Admin', className: 'planet-pluto', x: 96, y: 66, size: 9, glow: '#a67cff', textColor: '#ece0ff' },
+];
+
+const emptySettings: PlanetSettings = {
+  sun: { url: '', videoUrl: '' },
+  mercury: { url: '', videoUrl: '' },
+  venus: { url: '', videoUrl: '' },
+  earth: { url: '', videoUrl: '' },
+  mars: { url: '', videoUrl: '' },
+  jupiter: { url: '', videoUrl: '' },
+  saturn: { url: '', videoUrl: '' },
+  uranus: { url: '', videoUrl: '' },
+  neptune: { url: '', videoUrl: '' },
+  pluto: { url: '', videoUrl: '' },
+};
+
+function loadSettings(): PlanetSettings {
+  if (typeof window === 'undefined') return emptySettings;
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return emptySettings;
+  try {
+    return { ...emptySettings, ...(JSON.parse(raw) as Partial<PlanetSettings>) };
+  } catch {
+    return emptySettings;
+  }
+}
+
+function saveSettings(settings: PlanetSettings) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+}
 
 export default function PortalMap() {
-  const { permissions, isLive, isAdmin } = useAuth();
-
-  const [introActive, setIntroActive] = useState(checkFirstVisit);
-  const [logoState, setLogoState] = useState<LogoState>(() =>
-    checkFirstVisit() ? 'hidden' : 'persist'
-  );
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [settings, setSettings] = useState<PlanetSettings>(loadSettings);
+  const [activeVideo, setActiveVideo] = useState<{ planetId: PlanetId; url: string; targetUrl: string } | null>(null);
+  const [showAdmin, setShowAdmin] = useState(false);
+  const [draft, setDraft] = useState<PlanetSettings>(settings);
 
   useEffect(() => {
-    if (!introActive) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
 
-    const timers = [
-      setTimeout(() => setLogoState('glow'),    950),
-      setTimeout(() => setLogoState('flare'),  1200),
-      setTimeout(() => setLogoState('persist'), 2100),
-      setTimeout(() => {
-        localStorage.setItem(INTRO_KEY, 'true');
-        setIntroActive(false);
-      }, 3400),
-    ];
+    let raf = 0;
+    const stars = Array.from({ length: 220 }, (_, i) => ({
+      x: ((i * 83.1) % 100) / 100,
+      y: ((i * 53.7 + i * i) % 100) / 100,
+      base: 0.15 + (i % 7) * 0.09,
+      pulse: 1.4 + (i % 9) * 0.3,
+      phase: (i % 11) * 0.6,
+    }));
 
-    return () => timers.forEach(clearTimeout);
-  }, [introActive]);
+    const resize = () => {
+      canvas.width = canvas.clientWidth * window.devicePixelRatio;
+      canvas.height = canvas.clientHeight * window.devicePixelRatio;
+    };
 
-  const handlePortalClick = (portal: (typeof PORTALS)[0]) => {
-    if (!permissions.includes(portal.permissionKey)) return;
-    window.open(portal.url, '_blank', 'noopener,noreferrer');
+    resize();
+    window.addEventListener('resize', resize);
+
+    const render = (t: number) => {
+      const w = canvas.width;
+      const h = canvas.height;
+      ctx.clearRect(0, 0, w, h);
+      ctx.fillStyle = '#050a2f';
+      ctx.fillRect(0, 0, w, h);
+
+      stars.forEach((s, idx) => {
+        const pulse = 0.45 + 0.55 * Math.sin(t / 1000 * s.pulse + s.phase);
+        const r = (0.9 + (idx % 3) * 0.8 + pulse * 1.3) * window.devicePixelRatio;
+        const x = s.x * w;
+        const y = s.y * h;
+        const alpha = Math.min(1, s.base + pulse * 0.55);
+
+        ctx.beginPath();
+        ctx.fillStyle = `rgba(235,245,255,${alpha})`;
+        ctx.arc(x, y, r, 0, Math.PI * 2);
+        ctx.fill();
+      });
+
+      raf = requestAnimationFrame(render);
+    };
+
+    raf = requestAnimationFrame(render);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', resize);
+    };
+  }, []);
+
+
+  const handlePlanetClick = (planet: PlanetDef) => {
+    if (planet.id === 'pluto') {
+      setDraft(settings);
+      setShowAdmin(true);
+      return;
+    }
+
+    const conf = settings[planet.id];
+    if (!conf?.url) return;
+    if (conf.videoUrl) {
+      setActiveVideo({ planetId: planet.id, url: conf.videoUrl, targetUrl: conf.url });
+      return;
+    }
+    window.open(conf.url, '_blank', 'noopener,noreferrer');
+  };
+
+  const handleVideoEnd = () => {
+    if (!activeVideo) return;
+    window.open(activeVideo.targetUrl, '_blank', 'noopener,noreferrer');
+    setActiveVideo(null);
+  };
+
+  const handleVideoUpload = (planetId: PlanetId, file: File | null) => {
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = String(reader.result || '');
+      setDraft((prev) => ({ ...prev, [planetId]: { ...prev[planetId], videoUrl: dataUrl } }));
+    };
+    reader.readAsDataURL(file);
   };
 
   return (
-    <div className="relative h-screen w-full overflow-hidden bg-black">
+    <div className="solar-scene">
+      <canvas ref={canvasRef} className="solar-star-canvas" />
 
-      {/* Background — no extra filters that soften the image */}
-      <img
-        src={bgImage}
-        alt="Occu-Med galaxy portal"
-        className="absolute inset-0 h-full w-full object-cover"
-        style={{ imageRendering: 'auto', transform: 'translateZ(0)' }}
-      />
+      {PLANETS.map((planet) => (
+        <motion.button
+          key={planet.id}
+          className={`solar-planet ${planet.className}`}
+          style={{ left: `${planet.x}%`, top: `${planet.y}%`, width: `${planet.size}vmin`, height: `${planet.size}vmin`, '--planet-glow': planet.glow } as React.CSSProperties}
+          whileHover={{ scale: 1.05 }}
+          onClick={() => handlePlanetClick(planet)}
+        >
+          {planet.id === 'sun' && (
+            <div className="sun-logo-wrap">
+              <div className="sun-logo-mark">OM</div>
+              <div className="sun-logo-text">OCCU-MED</div>
+            </div>
+          )}
 
-      {/* Vignette */}
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_center,transparent_38%,rgba(0,0,0,0.5)_100%)]" />
+          <span className="planet-hover-label" style={{ color: planet.textColor }}>{planet.label}</span>
+        </motion.button>
+      ))}
 
-      {/* Stars */}
-      <div className="pointer-events-none absolute inset-0">
-        {stars.map((star) => (
-          <div
-            key={star.id}
-            className={star.bright ? 'star star-bright' : 'star'}
-            style={{
-              left: `${star.left}%`,
-              top:  `${star.top}%`,
-              width:  `${star.size}px`,
-              height: `${star.size}px`,
-              '--duration': `${star.duration}s`,
-              '--delay':    `${star.delay}s`,
-            } as React.CSSProperties}
-          />
-        ))}
-      </div>
-
-      {/* Comet intro — only rendered on first visit */}
-      {introActive && (
-        <div className="pointer-events-none absolute inset-0 overflow-hidden">
-          <div className="comet-head" />
+      {activeVideo && (
+        <div className="video-overlay">
+          <video src={activeVideo.url} controls autoPlay onEnded={handleVideoEnd} className="video-player" />
+          <button className="video-close" onClick={() => setActiveVideo(null)}>Close</button>
         </div>
       )}
 
-      {/* Center OCCU-MED logo */}
-      <div className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center">
-        <div className={`center-logo ${logoState === 'hidden' ? 'logo-hidden' : logoState === 'glow' ? 'logo-glow' : logoState === 'flare' ? 'logo-flare' : 'logo-persist'}`}>
-          OCCU&#8209;MED
-        </div>
-      </div>
-
-      {/* Top bar */}
-      <div className="absolute left-0 top-0 z-50 flex w-full items-center justify-between p-5 md:p-7">
-        <motion.div
-          initial={{ opacity: 0, y: -16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 1 }}
-          className="flex items-center gap-4"
-        >
-          <div className="text-sm font-bold uppercase tracking-[0.34em] text-white/45 md:text-base">
-            OCCU-MED
-          </div>
-          {!isLive && (
-            <div className="rounded-full border border-white/20 bg-black/25 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-white/70 backdrop-blur-md">
-              Setup Mode
+      {showAdmin && (
+        <div className="admin-overlay">
+          <div className="admin-panel">
+            <h2>Pluto Admin Panel</h2>
+            <p>Set video + destination URL for each planet.</p>
+            <div className="admin-grid">
+              {PLANETS.map((p) => (
+                <div key={p.id} className="admin-card">
+                  <strong>{p.label}</strong>
+                  <input
+                    type="url"
+                    placeholder="https://portal-url"
+                    value={draft[p.id].url}
+                    onChange={(e) => setDraft((prev) => ({ ...prev, [p.id]: { ...prev[p.id], url: e.target.value } }))}
+                  />
+                  <input
+                    type="url"
+                    placeholder="https://video-url.mp4"
+                    value={draft[p.id].videoUrl.startsWith('data:') ? '' : draft[p.id].videoUrl}
+                    onChange={(e) => setDraft((prev) => ({ ...prev, [p.id]: { ...prev[p.id], videoUrl: e.target.value } }))}
+                  />
+                  <input type="file" accept="video/*" onChange={(e) => handleVideoUpload(p.id, e.target.files?.[0] ?? null)} />
+                </div>
+              ))}
             </div>
-          )}
-        </motion.div>
-
-        <motion.div
-          initial={{ opacity: 0, y: -16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 1, delay: 0.15 }}
-        >
-          <Link
-            href={isLive && !isAdmin ? '/login' : '/admin'}
-            className="rounded-full border border-white/15 bg-black/25 px-4 py-2 text-xs font-semibold uppercase tracking-[0.22em] text-white/75 backdrop-blur-md transition hover:border-white/35 hover:text-white"
-          >
-            Admin
-          </Link>
-        </motion.div>
-      </div>
-
-      {/* Portal planets */}
-      {PORTALS.map((portal, idx) => {
-        const hasAccess = permissions.includes(portal.permissionKey);
-        const bloomDuration = 3.8 + (idx % 5) * 0.7;
-        const bloomDelay    = (idx * 0.65) % 3.5;
-
-        return (
-          <motion.button
-            key={portal.id}
-            aria-label={`${portal.label} portal`}
-            className={`group absolute z-20 flex -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full outline-none ${hasAccess ? 'cursor-pointer' : 'cursor-default'}`}
-            style={{
-              left:   `${portal.x}%`,
-              top:    `${portal.y}%`,
-              width:  `${portal.size}vmin`,
-              height: `${portal.size}vmin`,
-            }}
-            onClick={() => handlePortalClick(portal)}
-            whileHover={hasAccess ? { scale: 1.08 } : { scale: 1.01 }}
-            whileTap={hasAccess ? { scale: 0.97 } : undefined}
-          >
-            {/* Ambient bloom — always pulsing */}
-            <span
-              className="ambient-bloom absolute rounded-full"
-              style={{
-                inset: '-40%',
-                background: `radial-gradient(circle, ${portal.color}2a 0%, ${portal.color}0c 55%, transparent 80%)`,
-                '--bloom-duration': `${bloomDuration}s`,
-                '--bloom-delay':    `${bloomDelay}s`,
-              } as React.CSSProperties}
-            />
-
-            {/* Static base glow ring */}
-            <span
-              className="absolute inset-0 rounded-full opacity-40 blur-lg transition-opacity duration-500 group-hover:opacity-80"
-              style={{ boxShadow: `0 0 32px 10px ${portal.color}` }}
-            />
-
-            {/* Hover bloom burst */}
-            <span
-              className="absolute rounded-full opacity-0 transition-opacity duration-500 group-hover:opacity-100"
-              style={{
-                inset: '-18%',
-                boxShadow: `0 0 55px 14px ${portal.color}90, inset 0 0 28px ${portal.color}55`,
-              }}
-            />
-
-            {/* Label — invisible by default, floats up on hover */}
-            <span
-              className="portal-label pointer-events-none absolute left-1/2 -translate-x-1/2 translate-y-1.5 opacity-0 transition-all duration-500 group-hover:translate-y-0 group-hover:opacity-100"
-              style={{
-                bottom: '-2.4em',
-                color: portal.color,
-                textShadow: `0 0 8px ${portal.color}, 0 0 18px ${portal.color}80, 0 0 36px ${portal.color}40`,
-              }}
-            >
-              {portal.label}
-            </span>
-          </motion.button>
-        );
-      })}
+            <div className="admin-actions">
+              <button onClick={() => setShowAdmin(false)}>Cancel</button>
+              <button
+                onClick={() => {
+                  setSettings(draft);
+                  saveSettings(draft);
+                  setShowAdmin(false);
+                }}
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/occu-med-portal/src/index.css
+++ b/occu-med-portal/src/index.css
@@ -99,11 +99,12 @@
   text-shadow: 0 0 10px currentColor, 0 0 20px currentColor;
 }
 
+
 /* ── Stars ─────────────────────────────────────────────── */
 
 @keyframes twinkle {
-  0%, 100% { opacity: 0.12; transform: scale(0.85); }
-  50%       { opacity: 0.75; transform: scale(1.05); }
+  0%, 100% { opacity: 0.14; transform: scale(0.84); }
+  50%       { opacity: 0.72; transform: scale(1.05); }
 }
 
 @keyframes sparkle {
@@ -145,8 +146,8 @@
 /* ── Ambient planet bloom ──────────────────────────────── */
 
 @keyframes ambientBloom {
-  0%, 100% { opacity: 0.22; transform: scale(1); }
-  50%       { opacity: 0.52; transform: scale(1.18); }
+  0%, 100% { opacity: 0.2; transform: scale(1); }
+  50%       { opacity: 0.5; transform: scale(1.16); }
 }
 
 .ambient-bloom {
@@ -161,7 +162,7 @@
   0%   { transform: translate(-320px, 0); opacity: 0; }
   6%   { opacity: 1; }
   94%  { opacity: 1; }
-  100% { transform: translate(calc(100vw + 320px), 30vh); opacity: 0; }
+  100% { transform: translate(calc(100vw + 320px), 34vh); opacity: 0; }
 }
 
 .comet-head {
@@ -265,15 +266,204 @@
 /* ── Portal hover labels ───────────────────────────────── */
 
 .portal-label {
-  font-size: 9px;
-  font-weight: 600;
-  letter-spacing: 0.18em;
+  font-size: clamp(9px, 0.86vw, 13px);
+  font-weight: 700;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
   font-family: 'JetBrains Mono', monospace;
   white-space: nowrap;
+  padding: 0.32rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid rgba(235, 244, 255, 0.28);
+  background: linear-gradient(120deg, rgba(12, 16, 34, 0.78), rgba(13, 10, 28, 0.5));
+  backdrop-filter: blur(4px);
   transition: opacity 0.45s ease, transform 0.45s ease, letter-spacing 0.45s ease;
 }
 
 .group:hover .portal-label {
-  letter-spacing: 0.32em;
+  letter-spacing: 0.34em;
+}
+
+/* --- Solar portal recreation --- */
+.solar-scene {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
+  background: #050a2f;
+}
+
+.solar-star-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.solar-planet {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  outline: none;
+  background: transparent;
+  box-shadow: 0 0 22px color-mix(in srgb, var(--planet-glow) 70%, transparent);
+  transition: filter 260ms ease, box-shadow 260ms ease;
+}
+
+.solar-planet::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+}
+
+.solar-planet:hover {
+  filter: brightness(1.2);
+  box-shadow:
+    0 0 36px color-mix(in srgb, var(--planet-glow) 92%, transparent),
+    0 0 64px color-mix(in srgb, var(--planet-glow) 72%, transparent);
+}
+
+.planet-hover-label {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+  font-size: clamp(18px, 1.8vw, 34px);
+  opacity: 0;
+  text-shadow: 0 0 12px currentColor, 0 0 22px currentColor;
+  transition: opacity 220ms ease;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.solar-planet:hover .planet-hover-label {
+  opacity: 1;
+}
+
+.planet-sun::before {
+  background:
+    radial-gradient(circle at 35% 35%, #fff8bf 0%, #ffe767 20%, #ffd651 42%, #ffb63e 100%);
+}
+
+.sun-logo-wrap {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: #b16a20;
+  text-shadow: 0 0 10px rgba(255, 251, 210, 0.5);
+}
+
+.sun-logo-mark {
+  font-size: clamp(20px, 3vw, 52px);
+  font-weight: 900;
+  line-height: 1;
+}
+
+.sun-logo-text {
+  margin-top: -0.1em;
+  font-size: clamp(13px, 1.7vw, 28px);
+  font-weight: 900;
+}
+
+.planet-mercury::before {
+  background: repeating-linear-gradient(165deg, #f8d8a2 0 12%, #f2b777 12% 22%, #a45f86 22% 30%);
+}
+.planet-venus::before {
+  background: repeating-linear-gradient(160deg, #ff8c4c 0 14%, #cf4a3f 14% 26%, #f09148 26% 35%);
+}
+.planet-earth::before {
+  background: radial-gradient(circle at 36% 30%, #dbf2ff 0 8%, transparent 10%), #2f67df;
+}
+.planet-mars::before {
+  background: radial-gradient(circle at 65% 73%, #ff9ad1 0 12%, transparent 14%), #7f39c7;
+}
+.planet-jupiter::before {
+  background: repeating-linear-gradient(173deg, #ff9f42 0 9%, #4aa7ff 9% 18%, #8065ff 18% 28%, #db4f61 28% 35%);
+}
+.planet-saturn::before {
+  background: linear-gradient(170deg, #f9c463, #ef8f3d);
+}
+.planet-uranus::before {
+  background: repeating-linear-gradient(170deg, #c2f5ff 0 8%, #88d4e6 8% 20%, #63b8c9 20% 30%);
+}
+.planet-neptune::before {
+  background: radial-gradient(circle at 30% 45%, #74ecff 0 24%, #1b46d1 25% 100%);
+}
+.planet-pluto::before {
+  background: repeating-linear-gradient(155deg, #c09cff 0 10%, #9d79e1 10% 23%, #8062c7 23% 35%);
+}
+
+.planet-saturn::after {
+  content: '';
+  position: absolute;
+  inset: -22% -28%;
+  border-radius: 50%;
+  border: 0.8vmin solid rgba(89, 143, 255, 0.85);
+  transform: rotate(-20deg);
+  filter: drop-shadow(0 0 10px rgba(110, 163, 255, 0.75));
+}
+
+.video-overlay,
+.admin-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(2, 4, 17, 0.85);
+  display: grid;
+  place-items: center;
+  z-index: 80;
+}
+
+.video-player {
+  width: min(92vw, 1000px);
+  max-height: 84vh;
+  border-radius: 12px;
+}
+
+.video-close {
+  margin-top: 12px;
+}
+
+.admin-panel {
+  width: min(95vw, 1050px);
+  max-height: 86vh;
+  overflow: auto;
+  background: #090f2f;
+  border: 1px solid #33427f;
+  border-radius: 12px;
+  padding: 20px;
+}
+
+.admin-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 12px;
+}
+
+.admin-card {
+  display: grid;
+  gap: 8px;
+  background: #0f1740;
+  border: 1px solid #2f3e78;
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.admin-card input {
+  width: 100%;
+  background: #02071f;
+  border: 1px solid #32417c;
+  border-radius: 6px;
+  padding: 7px;
+}
+
+.admin-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 14px;
 }

--- a/occu-med-portal/vite.config.ts
+++ b/occu-med-portal/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
+import { existsSync } from "node:fs";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
 const rawPort = process.env.PORT;
@@ -17,6 +18,15 @@ const port = Number(rawPort);
 if (Number.isNaN(port) || port <= 0) {
   throw new Error(`Invalid PORT value: "${rawPort}"`);
 }
+
+const assetCandidates = [
+  path.resolve(import.meta.dirname, "..", "attached_assets"),
+  path.resolve(import.meta.dirname, "..", "..", "attached_assets"),
+];
+
+const attachedAssetsPath =
+  assetCandidates.find((candidate) => existsSync(candidate)) ??
+  assetCandidates[0];
 
 const basePath = process.env.BASE_PATH;
 
@@ -49,7 +59,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(import.meta.dirname, "src"),
-      "@assets": path.resolve(import.meta.dirname, "..", "..", "attached_assets"),
+      "@assets": attachedAssetsPath,
     },
     dedupe: ["react", "react-dom"],
   },


### PR DESCRIPTION
### Motivation

- Replace the previous static/intro portal map with an interactive, canvas-driven solar scene to provide richer visuals and per-planet behaviors. 
- Add an on-app admin panel to configure destination URLs and optional video previews per planet, stored in localStorage for persistence. 
- Make the project asset alias resolution robust to different repository layouts by selecting an existing `attached_assets` path at runtime.

### Description

- Reimplemented `PortalMap.tsx` to draw a procedurally animated starfield on a `<canvas>` and render a set of planets (`PLANETS`) as clickable `motion.button`s, removing the old background image/intro flow and `useAuth`/`PORTALS` dependency. 
- Added per-planet settings stored under the `occu_med_planet_routes_v1` key in `localStorage`, with UI to edit URLs and upload video files in an admin overlay triggered by clicking the Pluto planet; videos open in an in-app overlay and optionally redirect to the configured URL when playback ends. 
- Added new CSS rules in `index.css` for the solar scene, planets, overlays, and updated a few animation timings and portal label styles. 
- Updated `vite.config.ts` to detect an existing `attached_assets` directory (searching a couple of candidate locations via `existsSync`) and set the `@assets` alias to the discovered path instead of a fixed hardcoded path.

### Testing

- Built the app with the Vite production build (`vite build`) and verified the build completed successfully. 
- Ran TypeScript type checking (`tsc --noEmit`) against the modified files and there were no type errors. 
- No automated unit tests were changed or added in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b9e4c8408326a8987dd024dcb609)