### PR TITLE
Integrate Supabase backend and media upload into admin portal

### DIFF
--- a/occu-med-portal/src/components/PortalMap.tsx
+++ b/occu-med-portal/src/components/PortalMap.tsx
@@ -1,11 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { PORTALS, STORAGE_KEY, OPENING_VIDEO_KEY, type PortalDef, type PortalPermissionKey } from '../lib/config';
+import { loadPortalState, savePortalState, uploadPortalAsset, type ManagedUser, type PlanetSettings } from '../lib/portalBackend';
 
-interface PlanetSetting { url: string; videoUrl: string; }
-type PlanetSettings = Record<PortalPermissionKey, PlanetSetting>;
 type AdminTab = 'planets' | 'users' | 'launch';
-type ManagedUser = { email: string; role: 'Admin' | 'User'; permissions: PortalPermissionKey[] };
 type LaunchState = { iframeUrl: string; videoUrl: string | null; label: string; glow: string; videoOver: boolean; };
 
 const ARTWORK_SRC = '/assets/portal-solar-system-bg.mp4';
@@ -55,6 +53,41 @@ export default function PortalMap() {
   const [inviteEmail, setInviteEmail] = useState('');
   const [openingVideoUrl, setOpeningVideoUrl] = useState(() => typeof window !== 'undefined' ? localStorage.getItem(OPENING_VIDEO_KEY) ?? '' : '');
   const [audioUrl, setAudioUrl] = useState(() => typeof window !== 'undefined' ? localStorage.getItem(AUDIO_KEY) ?? '' : '');
+  const [isSaving, setIsSaving] = useState(false);
+  const [isUploadingAsset, setIsUploadingAsset] = useState(false);
+  const [saveMessage, setSaveMessage] = useState('');
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function hydrateFromBackend() {
+      const backendState = await loadPortalState();
+      if (!mounted || !backendState) return;
+
+      if (backendState.settings) {
+        setSettings((prev) => ({ ...prev, ...backendState.settings }));
+        setDraft((prev) => ({ ...prev, ...backendState.settings }));
+      }
+
+      if (backendState.users) {
+        setUsers(backendState.users);
+      }
+
+      if (typeof backendState.openingVideoUrl === 'string') {
+        setOpeningVideoUrl(backendState.openingVideoUrl);
+      }
+
+      if (typeof backendState.audioUrl === 'string') {
+        setAudioUrl(backendState.audioUrl);
+      }
+    }
+
+    void hydrateFromBackend();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   const handlePlanetClick = (planet: PortalDef) => {
     playClickSound();
@@ -64,24 +97,72 @@ export default function PortalMap() {
     setLaunch({ iframeUrl: conf.url, videoUrl: conf.videoUrl || null, label: planet.label, glow: planet.glow, videoOver: !conf.videoUrl });
   };
   const handleVideoEnd = () => { if (launch) setLaunch((prev) => prev ? { ...prev, videoOver: true } : null); };
-  const handleVideoUpload = (id: PortalPermissionKey, file: File | null) => {
+  const handleVideoUpload = async (id: PortalPermissionKey, file: File | null) => {
     if (!file) return;
-    const reader = new FileReader();
-    reader.onload = () => setDraft((prev) => ({ ...prev, [id]: { ...prev[id], videoUrl: String(reader.result || '') } }));
-    reader.readAsDataURL(file);
+
+    setIsUploadingAsset(true);
+    setSaveMessage('');
+    try {
+      const publicUrl = await uploadPortalAsset(file, 'transitions');
+      setDraft((prev) => ({ ...prev, [id]: { ...prev[id], videoUrl: publicUrl } }));
+      setSaveMessage('Transition video uploaded. Click Save Changes to publish.');
+    } catch (error) {
+      console.error(error);
+      setSaveMessage('Video upload failed. Please check Supabase Storage settings.');
+      alert('Video upload failed. Please check Supabase Storage settings.');
+    } finally {
+      setIsUploadingAsset(false);
+    }
   };
-  const handleOpeningVideoUpload = (file: File | null) => {
+  const handleOpeningVideoUpload = async (file: File | null) => {
     if (!file) return;
-    const reader = new FileReader();
-    reader.onload = () => setOpeningVideoUrl(String(reader.result || ''));
-    reader.readAsDataURL(file);
+
+    setIsUploadingAsset(true);
+    setSaveMessage('');
+    try {
+      const publicUrl = await uploadPortalAsset(file, 'opening');
+      setOpeningVideoUrl(publicUrl);
+      setSaveMessage('Opening video uploaded. Click Save Changes to publish.');
+    } catch (error) {
+      console.error(error);
+      setSaveMessage('Opening video upload failed. Please check Supabase Storage settings.');
+      alert('Opening video upload failed. Please check Supabase Storage settings.');
+    } finally {
+      setIsUploadingAsset(false);
+    }
   };
-  const handleSave = () => {
-    setSettings(draft); saveSettings(draft);
-    localStorage.setItem(USERS_KEY, JSON.stringify(users));
-    localStorage.setItem(OPENING_VIDEO_KEY, openingVideoUrl);
-    localStorage.setItem(AUDIO_KEY, audioUrl);
-    setShowAdmin(false);
+  const handleSave = async () => {
+    setIsSaving(true);
+    setSaveMessage('');
+
+    try {
+      const payload = {
+        settings: draft,
+        users,
+        openingVideoUrl,
+        audioUrl,
+      };
+
+      await savePortalState(payload);
+      setSettings(draft);
+      saveSettings(draft);
+      localStorage.setItem(USERS_KEY, JSON.stringify(users));
+      localStorage.setItem(OPENING_VIDEO_KEY, openingVideoUrl);
+      localStorage.setItem(AUDIO_KEY, audioUrl);
+      setSaveMessage('Saved successfully.');
+      setShowAdmin(false);
+    } catch (error) {
+      console.error(error);
+      setSettings(draft);
+      saveSettings(draft);
+      localStorage.setItem(USERS_KEY, JSON.stringify(users));
+      localStorage.setItem(OPENING_VIDEO_KEY, openingVideoUrl);
+      localStorage.setItem(AUDIO_KEY, audioUrl);
+      setSaveMessage('Backend save failed. Saved locally only.');
+      alert('Backend save failed. Saved locally only.');
+    } finally {
+      setIsSaving(false);
+    }
   };
   const handleAdminLogin = () => {
     if (!ADMIN_EMAIL || !ADMIN_PASSWORD) { setAdminError('Admin credentials are not configured in Render environment variables.'); return; }
@@ -104,7 +185,7 @@ export default function PortalMap() {
         <motion.button key={planet.id} className="planet-hotspot" style={{ left: `${planet.x}%`, top: `${planet.y}%`, width: `${planet.size}vmin`, height: `${planet.size}vmin` } as React.CSSProperties} whileHover={{ scale: 1.01 }} transition={{ type: 'spring', stiffness: 260, damping: 18 }} onClick={() => handlePlanetClick(planet)} aria-label={planet.label} title={planet.label} />
       ))}
       {launch && <div className="portal-launch-overlay"><iframe src={launch.iframeUrl} title={launch.label} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', border: 'none', opacity: launch.videoOver ? 1 : 0, transition: 'opacity 0.8s ease', zIndex: 1 }} allow="fullscreen" />{!launch.videoOver && <div className="portal-launch-loading">{launch.videoUrl ? <video src={launch.videoUrl} autoPlay playsInline onEnded={handleVideoEnd} className="portal-launch-video" /> : <div style={{ textAlign: 'center', zIndex: 3 }}><div className="launch-title" style={{ textShadow: `0 0 20px ${launch.glow}, 0 0 70px ${launch.glow}` }}>{launch.label}</div><div className="launch-subtitle">Portal waking up...</div></div>}</div>}<button onClick={launch.videoOver ? () => setLaunch(null) : handleVideoEnd} className="portal-close-button">{launch.videoOver ? 'Close' : 'Skip'}</button></div>}
-      {showAdmin && <div className="admin-overlay"><div className="admin-panel admin-panel-wide">{!adminUnlocked ? <div className="admin-login-card"><p className="admin-kicker">Occu-Med Secure Portal</p><h2>Admin Access Required</h2><p className="admin-login-help">Sign in to configure the full portal command center.</p><label>Email</label><input type="email" value={adminEmail} onChange={(e) => setAdminEmail(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && handleAdminLogin()} placeholder="name@occu-med.com" /><label>Password</label><input type="password" value={adminPassword} onChange={(e) => setAdminPassword(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && handleAdminLogin()} placeholder="Password" />{adminError && <div className="admin-error">{adminError}</div>}<div className="admin-actions"><button className="admin-btn-cancel" onClick={() => setShowAdmin(false)}>Cancel</button><button className="admin-btn-save" onClick={handleAdminLogin}>Unlock Admin</button></div></div> : <><div className="admin-panel-header"><h2>Admin Command Center</h2><p>One locked panel for planet links, users, permissions, and launch settings.</p></div><div className="admin-tabs"><button className={adminTab === 'planets' ? 'active' : ''} onClick={() => setAdminTab('planets')}>Planet Portals</button><button className={adminTab === 'users' ? 'active' : ''} onClick={() => setAdminTab('users')}>Users & Permissions</button><button className={adminTab === 'launch' ? 'active' : ''} onClick={() => setAdminTab('launch')}>Launch Experience</button></div>{adminTab === 'planets' && <div className="admin-grid admin-grid-wide">{PORTALS.map((p) => <div key={p.id} className="admin-card"><strong style={{ color: p.glow }}>{p.label}</strong><label>Render URL</label><input type="url" placeholder="https://your-app.onrender.com" value={draft[p.id].url} onChange={(e) => setDraft((prev) => ({ ...prev, [p.id]: { ...prev[p.id], url: e.target.value } }))} /><label>Transition Video URL</label><input type="url" placeholder="https://...video.mp4" value={draft[p.id].videoUrl.startsWith('data:') ? '' : draft[p.id].videoUrl} onChange={(e) => setDraft((prev) => ({ ...prev, [p.id]: { ...prev[p.id], videoUrl: e.target.value } }))} /><label>Or upload video file</label><input type="file" accept="video/*" onChange={(e) => handleVideoUpload(p.id, e.target.files?.[0] ?? null)} /></div>)}</div>}{adminTab === 'users' && <div className="admin-users"><div className="admin-invite"><input value={inviteEmail} onChange={(e) => setInviteEmail(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && addUser()} placeholder="name@occu-med.com" /><button className="admin-btn-save" onClick={addUser}>Add User</button></div>{users.map((u) => <div className="admin-user-row" key={u.email}><div><strong>{u.email}</strong><button onClick={() => toggleRole(u.email)}>{u.role}</button></div><div className="admin-permission-grid">{PORTALS.map((p) => <button key={p.id} className={u.permissions.includes(p.permissionKey) ? 'enabled' : ''} onClick={() => togglePermission(u.email, p.permissionKey)} style={{ '--portal-color': p.glow } as React.CSSProperties}>{p.label}</button>)}</div></div>)}</div>}{adminTab === 'launch' && <div className="admin-launch"><label>Opening Video URL</label><input value={openingVideoUrl.startsWith('data:') ? '' : openingVideoUrl} onChange={(e) => setOpeningVideoUrl(e.target.value)} placeholder="https://...opening.mp4" /><label>Or upload opening video</label><input type="file" accept="video/*" onChange={(e) => handleOpeningVideoUpload(e.target.files?.[0] ?? null)} /><label>Startup Audio URL</label><input value={audioUrl} onChange={(e) => setAudioUrl(e.target.value)} placeholder="https://...ambient.mp3" /></div>}<div className="admin-actions"><button className="admin-btn-cancel" onClick={() => setShowAdmin(false)}>Cancel</button><button className="admin-btn-save" onClick={handleSave}>Save Changes</button></div></>}</div></div>}
+      {showAdmin && <div className="admin-overlay"><div className="admin-panel admin-panel-wide">{!adminUnlocked ? <div className="admin-login-card"><p className="admin-kicker">Occu-Med Secure Portal</p><h2>Admin Access Required</h2><p className="admin-login-help">Sign in to configure the full portal command center.</p><label>Email</label><input type="email" value={adminEmail} onChange={(e) => setAdminEmail(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && handleAdminLogin()} placeholder="name@occu-med.com" /><label>Password</label><input type="password" value={adminPassword} onChange={(e) => setAdminPassword(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && handleAdminLogin()} placeholder="Password" />{adminError && <div className="admin-error">{adminError}</div>}<div className="admin-actions"><button className="admin-btn-cancel" onClick={() => setShowAdmin(false)}>Cancel</button><button className="admin-btn-save" onClick={handleAdminLogin}>Unlock Admin</button></div></div> : <><div className="admin-panel-header"><h2>Admin Command Center</h2><p>One locked panel for planet links, users, permissions, and launch settings.</p>{saveMessage && <div className="admin-save-message">{saveMessage}</div>}</div><div className="admin-tabs"><button className={adminTab === 'planets' ? 'active' : ''} onClick={() => setAdminTab('planets')}>Planet Portals</button><button className={adminTab === 'users' ? 'active' : ''} onClick={() => setAdminTab('users')}>Users & Permissions</button><button className={adminTab === 'launch' ? 'active' : ''} onClick={() => setAdminTab('launch')}>Launch Experience</button></div>{adminTab === 'planets' && <div className="admin-grid admin-grid-wide">{PORTALS.map((p) => <div key={p.id} className="admin-card"><strong style={{ color: p.glow }}>{p.label}</strong><label>Render URL</label><input type="url" placeholder="https://your-app.onrender.com" value={draft[p.id].url} onChange={(e) => setDraft((prev) => ({ ...prev, [p.id]: { ...prev[p.id], url: e.target.value } }))} /><label>Transition Video URL</label><input type="url" placeholder="https://...video.mp4" value={draft[p.id].videoUrl} onChange={(e) => setDraft((prev) => ({ ...prev, [p.id]: { ...prev[p.id], videoUrl: e.target.value } }))} /><label>Or upload video file</label><input type="file" accept="video/*" onChange={(e) => void handleVideoUpload(p.id, e.target.files?.[0] ?? null)} disabled={isUploadingAsset} /></div>)}</div>}{adminTab === 'users' && <div className="admin-users"><div className="admin-invite"><input value={inviteEmail} onChange={(e) => setInviteEmail(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && addUser()} placeholder="name@occu-med.com" /><button className="admin-btn-save" onClick={addUser}>Add User</button></div>{users.map((u) => <div className="admin-user-row" key={u.email}><div><strong>{u.email}</strong><button onClick={() => toggleRole(u.email)}>{u.role}</button></div><div className="admin-permission-grid">{PORTALS.map((p) => <button key={p.id} className={u.permissions.includes(p.permissionKey) ? 'enabled' : ''} onClick={() => togglePermission(u.email, p.permissionKey)} style={{ '--portal-color': p.glow } as React.CSSProperties}>{p.label}</button>)}</div></div>)}</div>}{adminTab === 'launch' && <div className="admin-launch"><label>Opening Video URL</label><input value={openingVideoUrl} onChange={(e) => setOpeningVideoUrl(e.target.value)} placeholder="https://...opening.mp4" /><label>Or upload opening video</label><input type="file" accept="video/*" onChange={(e) => void handleOpeningVideoUpload(e.target.files?.[0] ?? null)} disabled={isUploadingAsset} /><label>Startup Audio URL</label><input value={audioUrl} onChange={(e) => setAudioUrl(e.target.value)} placeholder="https://...ambient.mp3" /></div>}<div className="admin-actions"><button className="admin-btn-cancel" onClick={() => setShowAdmin(false)}>Cancel</button><button className="admin-btn-save" onClick={handleSave} disabled={isSaving || isUploadingAsset}>{isSaving ? 'Saving...' : isUploadingAsset ? 'Uploading...' : 'Save Changes'}</button></div></>}</div></div>}
     </div>
   );
 }

--- a/occu-med-portal/src/index.css
+++ b/occu-med-portal/src/index.css
@@ -232,6 +232,7 @@
 .admin-panel-header { margin-bottom: 12px; }
 .admin-panel-header h2 { margin: 0 0 4px; font-size: 1.25rem; font-weight: 800; }
 .admin-panel-header p { margin: 0; color: rgba(255,255,255,0.72); }
+.admin-save-message { margin-top: 8px; color: #9ef7ff; font-size: 0.9rem; }
 
 .admin-tabs {
   display: flex;

--- a/occu-med-portal/src/lib/portalBackend.ts
+++ b/occu-med-portal/src/lib/portalBackend.ts
@@ -1,17 +1,107 @@
 import { createClient } from '@supabase/supabase-js';
+import type { PortalPermissionKey } from './config';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+export type PlanetSetting = {
+  url: string;
+  videoUrl: string;
+};
 
-const supabase = createClient(supabaseUrl, supabaseKey);
+export type PlanetSettings = Record<PortalPermissionKey, PlanetSetting>;
 
-export async function savePortalSettings(data: any) {
+export type ManagedUser = {
+  email: string;
+  role: 'Admin' | 'User';
+  permissions: PortalPermissionKey[];
+};
+
+export type PortalBackendState = {
+  settings: PlanetSettings;
+  users: ManagedUser[];
+  openingVideoUrl: string;
+  audioUrl: string;
+};
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+const storageBucket = (import.meta.env.VITE_SUPABASE_STORAGE_BUCKET as string | undefined) ?? 'portal-assets';
+
+const supabase =
+  supabaseUrl && supabaseAnonKey
+    ? createClient(supabaseUrl, supabaseAnonKey)
+    : null;
+
+export async function loadPortalState(): Promise<Partial<PortalBackendState> | null> {
+  if (!supabase) return null;
+
+  const { data, error } = await supabase
+    .from('portal_settings')
+    .select('data')
+    .eq('id', 1)
+    .maybeSingle();
+
+  if (error) {
+    console.error('Supabase load failed:', error);
+    return null;
+  }
+
+  return (data?.data as Partial<PortalBackendState> | undefined) ?? null;
+}
+
+export async function savePortalState(state: PortalBackendState): Promise<void> {
+  if (!supabase) {
+    throw new Error('Supabase environment variables are missing.');
+  }
+
   const { error } = await supabase
     .from('portal_settings')
-    .upsert([{ id: 1, data }]);
+    .upsert({
+      id: 1,
+      data: state,
+      updated_at: new Date().toISOString(),
+    });
 
   if (error) {
     console.error('Supabase save failed:', error);
     throw error;
   }
+}
+
+function sanitizeFileName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+export async function uploadPortalAsset(
+  file: File,
+  pathPrefix: 'transitions' | 'opening' | 'audio',
+): Promise<string> {
+  if (!supabase) {
+    throw new Error('Supabase environment variables are missing.');
+  }
+
+  const ext = file.name.includes('.') ? file.name.split('.').pop() : 'bin';
+  const safeBaseName = sanitizeFileName(file.name.replace(/\.[^.]+$/, ''));
+  const filePath = `${pathPrefix}/${Date.now()}-${safeBaseName}.${ext}`;
+
+  const { error: uploadError } = await supabase.storage
+    .from(storageBucket)
+    .upload(filePath, file, {
+      cacheControl: '3600',
+      upsert: false,
+      contentType: file.type || undefined,
+    });
+
+  if (uploadError) {
+    console.error('Supabase upload failed:', uploadError);
+    throw uploadError;
+  }
+
+  const { data } = supabase.storage
+    .from(storageBucket)
+    .getPublicUrl(filePath);
+
+  if (!data.publicUrl) {
+    throw new Error('Failed to generate public URL for uploaded asset.');
+  }
+
+  return data.publicUrl;
 }


### PR DESCRIPTION
### Motivation
- Move portal configuration and user management off localStorage into a shared backend and allow uploading of media assets to Supabase Storage. 
- Provide a more robust admin UX with save/upload status and persistent settings for opening videos and startup audio.

### Description
- Added a new backend module `src/lib/portalBackend.ts` that initializes a Supabase client, defines types (`PlanetSettings`, `ManagedUser`, `PortalBackendState`), and implements `loadPortalState`, `savePortalState`, and `uploadPortalAsset` to persist settings and upload files to a configured storage bucket. 
- Updated `PortalMap.tsx` to hydrate state from the backend on mount via `loadPortalState`, and to call `savePortalState` when saving admin changes; localStorage fallbacks remain in place. 
- Replaced inline FileReader uploads with `uploadPortalAsset` calls for transition and opening videos, and added UI state flags (`isSaving`, `isUploadingAsset`, `saveMessage`) to disable controls and surface progress/messages to the admin. 
- Small style addition `admin-save-message` to `index.css` to display save/upload messages in the admin panel.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f001c19d008326ad26573c18e864fd)