### PR TITLE
Fix intro video fullscreen layout and startup audio playback behavior

### DIFF
--- a/occu-med-portal/src/App.tsx
+++ b/occu-med-portal/src/App.tsx
@@ -26,13 +26,25 @@ function OpeningVideo({ onDone }: { onDone: () => void }) {
   useEffect(() => {
     const video = videoRef.current;
     if (!video) return;
-    video.muted = true;
-    const attempt = video.play();
-    if (attempt) {
-      attempt
-        .then(() => setCanStart(true))
-        .catch(() => setCanStart(false));
-    }
+
+    const tryStart = async () => {
+      try {
+        video.muted = false;
+        video.volume = 1;
+        await video.play();
+        setCanStart(true);
+      } catch {
+        try {
+          video.muted = true;
+          await video.play();
+          setCanStart(true);
+        } catch {
+          setCanStart(false);
+        }
+      }
+    };
+
+    void tryStart();
   }, [videoUrl]);
 
   if (failed) return null;
@@ -43,7 +55,6 @@ function OpeningVideo({ onDone }: { onDone: () => void }) {
         ref={videoRef}
         src={videoUrl}
         autoPlay
-        muted
         playsInline
         preload="auto"
         className="opening-video"

--- a/occu-med-portal/src/index.css
+++ b/occu-med-portal/src/index.css
@@ -265,3 +265,40 @@
   .admin-grid-wide { grid-template-columns: 1fr; }
   .admin-invite { grid-template-columns: 1fr; }
 }
+
+.opening-video-overlay {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  background: #000;
+  z-index: 9999;
+  overflow: hidden;
+}
+
+.opening-video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  background: #000;
+}
+
+.opening-skip-button,
+.opening-start-button {
+  position: absolute;
+  left: 1rem;
+  z-index: 10000;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(0, 0, 0, 0.45);
+  color: #fff;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.opening-skip-button { bottom: 1rem; }
+.opening-start-button { bottom: 3.25rem; }


### PR DESCRIPTION
### Motivation
- Ensure the opening intro presents as a full-bleed, fixed overlay instead of a small boxed element so the portal looks correct on load. 
- Restore startup audio where possible by attempting unmuted playback first and falling back to muted autoplay when browser policies block audio. 
- Keep the intro controls visible and usable when autoplay is blocked so users can still enter or skip the intro.

### Description
- Update `occu-med-portal/src/App.tsx` to change the opening video playback logic to attempt unmuted playback first (`video.muted = false`, `video.volume = 1`) and fall back to muted playback on error, and remove the `muted` attribute from the `<video>` element. 
- Add full-viewport overlay and video styles in `occu-med-portal/src/index.css` (`.opening-video-overlay`, `.opening-video`) to make the intro video cover the entire viewport with `object-fit: cover`. 
- Add styling for the intro controls (`.opening-start-button`, `.opening-skip-button`) with explicit positions and `z-index` so buttons remain visible above the video.

### Testing
- Ran a production build with `cd occu-med-portal && npm run build` and the build completed successfully. 
- Verified the intro overlay and control styles were emitted into the final CSS by inspecting the built assets (no runtime test failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1551071b88326905d26208008c0cd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced opening video playback with improved autoplay support
  * Added skip and start controls to the opening video interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->