### PR TITLE
Implement admin-created portal user access controls (no Supabase Auth)

### DIFF
--- a/occu-med-portal/src/components/PortalMap.tsx
+++ b/occu-med-portal/src/components/PortalMap.tsx
@@ -2,7 +2,8 @@ import { useEffect, useRef, useState } from 'react';
 import { useLocation } from 'wouter';
 import { motion } from 'framer-motion';
 import { PORTALS, type PortalDef, type PortalPermissionKey } from '@/lib/config';
-import { loadPortalState, type PlanetSettings } from '@/lib/portalBackend';
+import { loadPortalState, type ManagedUser, type PlanetSettings } from '@/lib/portalBackend';
+import { digestAccessCode, normalizeUsername } from '@/lib/accessControl';
 import { useAuth } from '../hooks/useAuth';
 
 type LaunchState = {
@@ -22,11 +23,15 @@ function buildEmpty(): PlanetSettings {
 }
 
 export default function PortalMap() {
-  const { user, permissions, loading: authLoading, isLive, isAdmin } = useAuth();
+  const { user, loading: authLoading, isAdmin } = useAuth();
   const [, setLocation] = useLocation();
   const [settings, setSettings] = useState<PlanetSettings>(() => buildEmpty());
   const [audioUrl, setAudioUrl] = useState('');
   const [launch, setLaunch] = useState<LaunchState | null>(null);
+  const [users, setUsers] = useState<ManagedUser[]>([]);
+  const [accessPlanet, setAccessPlanet] = useState<PortalDef | null>(null);
+  const [accessUsername, setAccessUsername] = useState('');
+  const [accessCode, setAccessCode] = useState('');
   const [notice, setNotice] = useState('');
   const [isLoadingConfig, setIsLoadingConfig] = useState(true);
   const launchVideoRef = useRef<HTMLVideoElement | null>(null);
@@ -36,7 +41,7 @@ export default function PortalMap() {
     let mounted = true;
 
     async function loadSharedPortalConfig() {
-      if (isLive && authLoading) return;
+      if (authLoading) return;
       setIsLoadingConfig(true);
       setNotice('');
 
@@ -46,9 +51,11 @@ export default function PortalMap() {
 
         if (backendState?.settings) {
           setSettings({ ...buildEmpty(), ...backendState.settings });
-        } else if (isLive && user) {
+        } else {
           setNotice('Portal links are not configured yet. An admin needs to save them in the Admin Command Center.');
         }
+
+        setUsers(Array.isArray(backendState?.users) ? backendState.users : []);
 
         if (typeof backendState?.audioUrl === 'string') {
           setAudioUrl(backendState.audioUrl);
@@ -67,45 +74,61 @@ export default function PortalMap() {
     return () => {
       mounted = false;
     };
-  }, [authLoading, isLive, user]);
+  }, [authLoading]);
 
-  const redirectToLogin = () => {
-    setLocation('/login?next=/');
+  const openPortal = (planet: PortalDef) => {
+    const conf = settings[planet.id as PortalPermissionKey];
+    const url = conf?.url?.trim();
+
+    if (!url) {
+      setNotice(`${planet.label} does not have a link configured yet.`);
+      return;
+    }
+
+    const transitionVideo = conf.videoUrl?.trim() || null;
+    if (!transitionVideo) {
+      window.open(url, '_blank', 'noopener,noreferrer');
+      return;
+    }
+
+    setLaunch({
+      targetUrl: url,
+      videoUrl: transitionVideo,
+      label: planet.label,
+      glow: planet.glow,
+      videoOver: false,
+    });
   };
 
-  const requirePortalAccess = (planet: PortalDef): boolean => {
-    if (!isLive) {
-      setNotice('Supabase is not configured yet, so secure portal access cannot be checked.');
-      return false;
+  const submitPortalAccess = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!accessPlanet) return;
+
+    const username = normalizeUsername(accessUsername);
+    const codeDigest = await digestAccessCode(accessCode);
+    const matchedUser = users.find((entry) => entry.username === username && entry.codeDigest === codeDigest);
+
+    if (!matchedUser) {
+      setNotice('Invalid username or password.');
+      return;
     }
 
-    if (authLoading) {
-      setNotice('Checking your portal access...');
-      return false;
+    if (!matchedUser.permissions.includes(accessPlanet.permissionKey)) {
+      setNotice(`This user does not have access to ${accessPlanet.label}.`);
+      return;
     }
 
-    if (!user) {
-      redirectToLogin();
-      return false;
-    }
-
-    if (!permissions.includes(planet.permissionKey)) {
-      setNotice(`Your account does not currently have access to the ${planet.label} portal.`);
-      return false;
-    }
-
-    return true;
+    const planet = accessPlanet;
+    setAccessPlanet(null);
+    setAccessUsername('');
+    setAccessCode('');
+    openPortal(planet);
   };
 
   const handlePlanetClick = (planet: PortalDef) => {
     setNotice('');
 
     if (planet.id === 'admin') {
-      if (!isLive) {
-        setLocation('/admin');
-        return;
-      }
-
       if (authLoading) {
         setNotice('Checking admin access...');
         return;
@@ -125,28 +148,7 @@ export default function PortalMap() {
       return;
     }
 
-    if (!requirePortalAccess(planet)) return;
-
-    const conf = settings[planet.id as PortalPermissionKey];
-    const url = conf?.url?.trim();
-
-    if (!url) {
-      setNotice(`${planet.label} does not have a link configured yet.`);
-      return;
-    }
-
-    const transitionVideo = conf.videoUrl?.trim() || null;
-    if (!transitionVideo) {
-      window.open(url, '_blank', 'noopener,noreferrer');
-      return;
-    }
-    setLaunch({
-      targetUrl: url,
-      videoUrl: transitionVideo,
-      label: planet.label,
-      glow: planet.glow,
-      videoOver: false,
-    });
+    setAccessPlanet(planet);
   };
 
   const handleVideoEnd = () => {
@@ -216,6 +218,47 @@ export default function PortalMap() {
       {(notice || isLoadingConfig) && (
         <div className="portal-status-message">
           {notice || 'Loading secure portal configuration...'}
+        </div>
+      )}
+
+      {accessPlanet && (
+        <div className="portal-launch-overlay">
+          <form
+            onSubmit={submitPortalAccess}
+            className="w-[min(92vw,420px)] rounded-3xl border border-white/15 bg-black/80 p-6 text-white shadow-2xl backdrop-blur-xl"
+          >
+            <p className="text-xs font-semibold uppercase tracking-[0.25em] text-cyan-100/70">Portal Access</p>
+            <h2 className="mt-2 text-2xl font-bold">{accessPlanet.label}</h2>
+            <p className="mt-2 text-sm text-white/55">Enter the username and PIN/password provided by an admin.</p>
+            <div className="mt-5 space-y-3">
+              <input
+                value={accessUsername}
+                onChange={(event) => setAccessUsername(event.target.value)}
+                placeholder="Username"
+                className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white outline-none placeholder:text-white/35 focus:border-cyan-200/50"
+                autoFocus
+                required
+              />
+              <input
+                type="password"
+                value={accessCode}
+                onChange={(event) => setAccessCode(event.target.value)}
+                placeholder="Password/PIN"
+                className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white outline-none placeholder:text-white/35 focus:border-cyan-200/50"
+                required
+              />
+            </div>
+            <div className="mt-5 flex gap-3">
+              <button type="submit" className="flex-1 rounded-xl bg-white px-4 py-3 text-sm font-semibold text-black hover:bg-cyan-100">Open Portal</button>
+              <button
+                type="button"
+                onClick={() => { setAccessPlanet(null); setAccessUsername(''); setAccessCode(''); }}
+                className="rounded-xl border border-white/15 bg-white/5 px-4 py-3 text-sm font-semibold text-white/75 hover:bg-white/10"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
         </div>
       )}
 

--- a/occu-med-portal/src/hooks/useAuth.tsx
+++ b/occu-med-portal/src/hooks/useAuth.tsx
@@ -1,66 +1,77 @@
-import { useState, useEffect } from 'react';
-import { supabase } from '../lib/supabase';
-import type { User } from '@supabase/supabase-js';
-import { PORTALS, type PortalPermissionKey } from '../lib/config';
+import { useEffect, useState } from 'react';
 
-type PortalRole = 'Admin' | 'User';
+const ADMIN_SESSION_KEY = 'occu_med_admin_session_v1';
+
+export type AdminSession = {
+  email: string;
+  createdAt: string;
+};
+
+function getConfiguredAdminEmail(): string {
+  return (import.meta.env.VITE_ADMIN_EMAIL as string | undefined)?.trim().toLowerCase() ?? '';
+}
+
+function getConfiguredAdminPassword(): string {
+  return (import.meta.env.VITE_ADMIN_PASSWORD as string | undefined)?.trim() ?? '';
+}
+
+function readAdminSession(): AdminSession | null {
+  if (typeof window === 'undefined') return null;
+  const raw = window.localStorage.getItem(ADMIN_SESSION_KEY) ?? window.sessionStorage.getItem(ADMIN_SESSION_KEY);
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as AdminSession;
+    return parsed.email === getConfiguredAdminEmail() ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function loginAdmin(email: string, password: string, remember = true): boolean {
+  const configuredEmail = getConfiguredAdminEmail();
+  const configuredPassword = getConfiguredAdminPassword();
+  const matches =
+    configuredEmail.length > 0 &&
+    configuredPassword.length > 0 &&
+    email.trim().toLowerCase() === configuredEmail &&
+    password === configuredPassword;
+
+  if (!matches || typeof window === 'undefined') return false;
+
+  const session: AdminSession = { email: configuredEmail, createdAt: new Date().toISOString() };
+  const storage = remember ? window.localStorage : window.sessionStorage;
+  storage.setItem(ADMIN_SESSION_KEY, JSON.stringify(session));
+  return true;
+}
+
+export function logoutAdmin(): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.removeItem(ADMIN_SESSION_KEY);
+  window.sessionStorage.removeItem(ADMIN_SESSION_KEY);
+}
 
 export function useAuth() {
-  const [user, setUser] = useState<User | null>(null);
-  const [role, setRole] = useState<PortalRole>('User');
+  const [user, setUser] = useState<AdminSession | null>(() => readAdminSession());
   const [loading, setLoading] = useState(true);
-  const [permissions, setPermissions] = useState<PortalPermissionKey[]>(PORTALS.map((p) => p.permissionKey));
 
   useEffect(() => {
-    if (!supabase) {
-      setLoading(false);
-      return;
-    }
+    setUser(readAdminSession());
+    setLoading(false);
 
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setUser(session?.user ?? null);
-      if (session?.user) {
-        fetchProfile(session.user);
-      } else {
-        setPermissions([]);
-        setLoading(false);
-      }
-    });
-
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
-      setUser(session?.user ?? null);
-      if (session?.user) {
-        fetchProfile(session.user);
-      } else {
-        setPermissions([]);
-        setRole('User');
-        setLoading(false);
-      }
-    });
-
-    return () => subscription.unsubscribe();
+    const onStorage = () => setUser(readAdminSession());
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
   }, []);
 
-  const fetchProfile = async (currentUser: User) => {
-    try {
-      if (!supabase || !currentUser.email) return;
-      const { data, error } = await supabase
-        .from('portal_users')
-        .select('role, permissions')
-        .eq('email', currentUser.email.toLowerCase())
-        .maybeSingle();
-
-      if (!error && data) {
-        setRole(data.role === 'Admin' ? 'Admin' : 'User');
-        setPermissions(Array.isArray(data.permissions) ? data.permissions : []);
-      } else {
-        setRole('User');
-        setPermissions([]);
-      }
-    } finally {
-      setLoading(false);
-    }
+  return {
+    user,
+    role: user ? 'Admin' : 'User',
+    permissions: [],
+    loading,
+    isLive: true,
+    isAdmin: !!user,
+    loginAdmin,
+    logoutAdmin,
   };
-
-  return { user, role, permissions, loading, isLive: !!supabase, isAdmin: role === 'Admin' };
 }

--- a/occu-med-portal/src/lib/accessControl.ts
+++ b/occu-med-portal/src/lib/accessControl.ts
@@ -1,0 +1,47 @@
+import type { PortalPermissionKey } from './config';
+
+export type PortalManagedUser = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  username: string;
+  codeDigest: string;
+  permissions: PortalPermissionKey[];
+};
+
+export const NON_ADMIN_PORTAL_KEYS: PortalPermissionKey[] = [
+  'leadership',
+  'exam_qa',
+  'scheduling',
+  'harvesting',
+  'sme',
+  'operations',
+  'new',
+  'network',
+  'shared',
+];
+
+export function normalizeUsername(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+export function buildUsername(firstName: string, lastName: string): string {
+  return normalizeUsername(`${firstName}${lastName}`);
+}
+
+export function generateAccessCode(): string {
+  const bytes = new Uint8Array(6);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => (byte % 10).toString()).join('');
+}
+
+export async function digestAccessCode(code: string): Promise<string> {
+  const data = new TextEncoder().encode(code.trim());
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hashBuffer), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+export function createUserId(): string {
+  if ('randomUUID' in crypto) return crypto.randomUUID();
+  return `user-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}

--- a/occu-med-portal/src/lib/portalBackend.ts
+++ b/occu-med-portal/src/lib/portalBackend.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import type { PortalPermissionKey } from './config';
+import type { PortalManagedUser } from './accessControl';
 
 export type PlanetSetting = {
   url: string;
@@ -8,17 +9,13 @@ export type PlanetSetting = {
 
 export type PlanetSettings = Record<PortalPermissionKey, PlanetSetting>;
 
-export type ManagedUser = {
-  id?: string;
-  email: string;
-  role: 'Admin' | 'User';
-  permissions: PortalPermissionKey[];
-};
+export type ManagedUser = PortalManagedUser;
 
 export type PortalBackendState = {
   settings?: Partial<PlanetSettings>;
   openingVideoUrl?: string;
   audioUrl?: string;
+  users?: PortalManagedUser[];
 };
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;

--- a/occu-med-portal/src/pages/Admin.tsx
+++ b/occu-med-portal/src/pages/Admin.tsx
@@ -1,56 +1,28 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useLocation } from 'wouter';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '../components/ui/card';
 import { Button } from '../components/ui/button';
 import { PORTALS, type PortalPermissionKey } from '../lib/config';
-import { supabase } from '../lib/supabase';
-import {
-  loadPortalState,
-  savePortalState,
-  uploadPortalAsset,
-  type ManagedUser,
-  type PlanetSettings,
-} from '../lib/portalBackend';
+import { loadPortalState, savePortalState, uploadPortalAsset, type ManagedUser, type PlanetSettings } from '../lib/portalBackend';
 import { useAuth } from '../hooks/useAuth';
+import { buildUsername, createUserId, digestAccessCode, generateAccessCode, NON_ADMIN_PORTAL_KEYS } from '../lib/accessControl';
 
 type AdminTab = 'users' | 'portals' | 'launch';
 
-type PortalUserRow = {
-  id?: string;
-  email: string;
-  role: string;
-  permissions: unknown;
-};
-
-const INVITABLE_PORTALS = PORTALS.filter((portal) => portal.id !== 'admin');
+const USER_PORTALS = PORTALS.filter((portal) => portal.id !== 'admin' && NON_ADMIN_PORTAL_KEYS.includes(portal.permissionKey));
 
 function buildEmptySettings(): PlanetSettings {
-  return Object.fromEntries(
-    PORTALS.map((portal) => [portal.id, { url: portal.url, videoUrl: portal.videoUrl }]),
-  ) as PlanetSettings;
-}
-
-function normalizeUser(row: PortalUserRow): ManagedUser {
-  return {
-    id: row.id,
-    email: row.email.toLowerCase(),
-    role: row.role === 'Admin' ? 'Admin' : 'User',
-    permissions: Array.isArray(row.permissions) ? (row.permissions as PortalPermissionKey[]) : [],
-  };
-}
-
-function buildUser(email: string, permissions: PortalPermissionKey[] = []): ManagedUser {
-  return { email: email.toLowerCase(), role: 'User', permissions };
+  return Object.fromEntries(PORTALS.map((portal) => [portal.id, { url: portal.url, videoUrl: portal.videoUrl }])) as PlanetSettings;
 }
 
 export default function Admin() {
-  const { isLive, user, loading, isAdmin } = useAuth();
+  const { user, loading, isAdmin, logoutAdmin } = useAuth();
   const [, setLocation] = useLocation();
-
   const [activeTab, setActiveTab] = useState<AdminTab>('users');
   const [users, setUsers] = useState<ManagedUser[]>([]);
-  const [inviteEmail, setInviteEmail] = useState('');
-  const [invitePermissions, setInvitePermissions] = useState<PortalPermissionKey[]>([]);
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [generatedCode, setGeneratedCode] = useState<{ username: string; code: string } | null>(null);
   const [draftSettings, setDraftSettings] = useState<PlanetSettings>(() => buildEmptySettings());
   const [openingVideoUrl, setOpeningVideoUrl] = useState('');
   const [audioUrl, setAudioUrl] = useState('');
@@ -58,588 +30,170 @@ export default function Admin() {
   const [isUploading, setIsUploading] = useState(false);
   const [message, setMessage] = useState('');
 
-  const canManage = useMemo(() => !isLive || isAdmin, [isLive, isAdmin]);
+  const usernamePreview = buildUsername(firstName, lastName);
 
   useEffect(() => {
     if (loading) return;
-    if (isLive && !user) {
-      setLocation('/login?next=/admin');
-      return;
-    }
-    if (isLive && user && !isAdmin) {
-      setMessage('This account is signed in, but it does not have Admin role access.');
-    }
-  }, [isLive, isAdmin, loading, setLocation, user]);
+    if (!user || !isAdmin) setLocation('/login?next=/admin');
+  }, [isAdmin, loading, setLocation, user]);
 
   useEffect(() => {
     let mounted = true;
-
     async function loadSharedSettings() {
-      if (isLive && loading) return;
-
       try {
         const backendState = await loadPortalState();
         if (!mounted) return;
-
-        if (backendState?.settings) {
-          setDraftSettings({ ...buildEmptySettings(), ...backendState.settings });
-        }
-
-        if (typeof backendState?.openingVideoUrl === 'string') {
-          setOpeningVideoUrl(backendState.openingVideoUrl);
-        }
-
-        if (typeof backendState?.audioUrl === 'string') {
-          setAudioUrl(backendState.audioUrl);
-        }
+        setDraftSettings({ ...buildEmptySettings(), ...(backendState?.settings ?? {}) });
+        setOpeningVideoUrl(typeof backendState?.openingVideoUrl === 'string' ? backendState.openingVideoUrl : '');
+        setAudioUrl(typeof backendState?.audioUrl === 'string' ? backendState.audioUrl : '');
+        setUsers(Array.isArray(backendState?.users) ? backendState.users : []);
       } catch (error: unknown) {
         if (!mounted) return;
         const detail = error instanceof Error ? error.message : 'Unknown backend error';
-        setMessage(`Unable to load portal settings from Supabase: ${detail}`);
+        setMessage(`Unable to load portal settings: ${detail}`);
       }
     }
-
     void loadSharedSettings();
-
     return () => {
       mounted = false;
     };
-  }, [isLive, loading]);
+  }, []);
 
-  useEffect(() => {
-    if (!isLive || !supabase || !isAdmin) return;
-
-    supabase
-      .from('portal_users')
-      .select('id, email, role, permissions')
-      .order('email')
-      .then(({ data, error }) => {
-        if (error) {
-          setMessage(`Unable to load portal users. Check the portal_users table and RLS policies. ${error.message}`);
-          return;
-        }
-
-        const rows = (data ?? []) as PortalUserRow[];
-        setUsers(rows.map(normalizeUser));
-      });
-  }, [isLive, isAdmin]);
-
-  const toggleInvitePermission = (permission: PortalPermissionKey) => {
-    setInvitePermissions((current) =>
-      current.includes(permission)
-        ? current.filter((item) => item !== permission)
-        : [...current, permission],
-    );
+  const persistState = async (nextUsers = users) => {
+    await savePortalState({ settings: draftSettings, openingVideoUrl, audioUrl, users: nextUsers });
   };
 
-  const inviteUser = async () => {
-    const email = inviteEmail.trim().toLowerCase();
-    if (!email || !canManage) return;
-
+  const addUser = async () => {
+    if (!usernamePreview || saving) return;
     setSaving(true);
     setMessage('');
-
     try {
-      const nextUser = buildUser(email, invitePermissions);
-
-      if (isLive) {
-        if (!supabase) throw new Error('Supabase is not configured.');
-
-        const { error: upsertError } = await supabase
-          .from('portal_users')
-          .upsert(nextUser, { onConflict: 'email' });
-
-        if (upsertError) throw upsertError;
-
-        const { error: inviteError } = await supabase.auth.signInWithOtp({
-          email,
-          options: {
-            shouldCreateUser: true,
-            emailRedirectTo: `${window.location.origin}/setup-account`,
-          },
-        });
-
-        if (inviteError) throw inviteError;
-      }
-
-      setUsers((current) => {
-        const existing = current.some((entry) => entry.email === email);
-        return existing
-          ? current.map((entry) => (entry.email === email ? { ...entry, permissions: invitePermissions } : entry))
-          : [...current, nextUser];
-      });
-      setInviteEmail('');
-      setInvitePermissions([]);
-      setMessage(
-        isLive
-          ? `Invitation sent to ${email} with ${invitePermissions.length} portal${invitePermissions.length === 1 ? '' : 's'} assigned.`
-          : `Preview user added: ${email}`,
-      );
+      const code = generateAccessCode();
+      const codeDigest = await digestAccessCode(code);
+      const nextUser: ManagedUser = {
+        id: createUserId(),
+        firstName: firstName.trim(),
+        lastName: lastName.trim(),
+        username: usernamePreview,
+        codeDigest,
+        permissions: [],
+      };
+      const nextUsers = [...users.filter((entry) => entry.username !== nextUser.username), nextUser];
+      setUsers(nextUsers);
+      await persistState(nextUsers);
+      setGeneratedCode({ username: nextUser.username, code });
+      setFirstName('');
+      setLastName('');
+      setMessage(`Created ${nextUser.username}. Copy the generated PIN now.`);
     } catch (error: unknown) {
-      const detail = error instanceof Error ? error.message : 'Unknown invite error';
-      setMessage(`Unable to invite user: ${detail}`);
+      const detail = error instanceof Error ? error.message : 'Unknown create error';
+      setMessage(`Unable to create user: ${detail}`);
     } finally {
       setSaving(false);
     }
   };
 
-  const removeUser = async (email: string) => {
-    if (!canManage) return;
-
+  const regenerateCode = async (id: string) => {
     setSaving(true);
     setMessage('');
-
     try {
-      if (isLive) {
-        if (!supabase) throw new Error('Supabase is not configured.');
-        const { error } = await supabase.from('portal_users').delete().eq('email', email);
-        if (error) throw error;
-      }
-
-      setUsers((current) => current.filter((entry) => entry.email !== email));
-      setMessage(`Removed ${email}.`);
-    } catch (error: unknown) {
-      const detail = error instanceof Error ? error.message : 'Unknown delete error';
-      setMessage(`Unable to remove user: ${detail}`);
+      const code = generateAccessCode();
+      const codeDigest = await digestAccessCode(code);
+      const target = users.find((entry) => entry.id === id);
+      const nextUsers = users.map((entry) => (entry.id === id ? { ...entry, codeDigest } : entry));
+      setUsers(nextUsers);
+      await persistState(nextUsers);
+      setGeneratedCode(target ? { username: target.username, code } : null);
+      setMessage('Generated a new PIN. Copy it now.');
     } finally {
       setSaving(false);
     }
   };
 
-  const togglePermission = (email: string, permission: PortalPermissionKey) => {
-    if (!canManage) return;
-    setUsers((current) =>
-      current.map((entry) => {
-        if (entry.email !== email) return entry;
-        const hasPermission = entry.permissions.includes(permission);
-        return {
-          ...entry,
-          permissions: hasPermission
-            ? entry.permissions.filter((item) => item !== permission)
-            : [...entry.permissions, permission],
-        };
-      }),
-    );
+  const removeUser = async (id: string) => {
+    const nextUsers = users.filter((entry) => entry.id !== id);
+    setUsers(nextUsers);
+    await persistState(nextUsers);
+    setMessage('User removed.');
   };
 
-  const toggleRole = (email: string) => {
-    if (!canManage) return;
-    setUsers((current) =>
-      current.map((entry) =>
-        entry.email === email
-          ? { ...entry, role: entry.role === 'Admin' ? 'User' : 'Admin' }
-          : entry,
-      ),
-    );
-  };
-
-  const grantAll = (email: string) => {
-    if (!canManage) return;
-    setUsers((current) =>
-      current.map((entry) =>
-        entry.email === email
-          ? { ...entry, permissions: INVITABLE_PORTALS.map((portal) => portal.permissionKey) }
-          : entry,
-      ),
-    );
-  };
-
-  const revokeAll = (email: string) => {
-    if (!canManage) return;
-    setUsers((current) =>
-      current.map((entry) => (entry.email === email ? { ...entry, permissions: [] } : entry)),
-    );
+  const togglePermission = (id: string, permission: PortalPermissionKey) => {
+    setUsers((current) => current.map((entry) => {
+      if (entry.id !== id) return entry;
+      const hasPermission = entry.permissions.includes(permission);
+      return { ...entry, permissions: hasPermission ? entry.permissions.filter((item) => item !== permission) : [...entry.permissions, permission] };
+    }));
   };
 
   const saveChanges = async () => {
-    if (!canManage) return;
-
     setSaving(true);
     setMessage('');
-
     try {
-      if (isLive) {
-        if (!supabase) throw new Error('Supabase is not configured.');
-
-        const { error: usersError } = await supabase
-          .from('portal_users')
-          .upsert(users, { onConflict: 'email' });
-
-        if (usersError) throw usersError;
-      }
-
-      await savePortalState({
-        settings: draftSettings,
-        openingVideoUrl,
-        audioUrl,
-      });
-
-      setMessage(isLive ? 'Portal settings and user permissions saved to Supabase.' : 'Preview settings saved for this session.');
+      await persistState();
+      setMessage('Portal links, launch settings, and user access saved.');
     } catch (error: unknown) {
       const detail = error instanceof Error ? error.message : 'Unknown save error';
-      setMessage(`Unable to save. Check Supabase tables and RLS policies. ${detail}`);
+      setMessage(`Unable to save portal state: ${detail}`);
     } finally {
       setSaving(false);
     }
   };
 
   const handleVideoUpload = async (portalId: PortalPermissionKey, file: File | null) => {
-    if (!file || !canManage) return;
-
+    if (!file) return;
     setIsUploading(true);
-    setMessage('');
-
     try {
       const publicUrl = await uploadPortalAsset(file, 'transitions');
-      setDraftSettings((current) => ({
-        ...current,
-        [portalId]: { ...current[portalId], videoUrl: publicUrl },
-      }));
+      setDraftSettings((current) => ({ ...current, [portalId]: { ...current[portalId], videoUrl: publicUrl } }));
       setMessage('Transition video uploaded. Click Save Changes to publish.');
-    } catch (error: unknown) {
-      const detail = error instanceof Error ? error.message : 'Unknown upload error';
-      setMessage(`Video upload failed. Check the portal-assets bucket. ${detail}`);
     } finally {
       setIsUploading(false);
     }
   };
 
   const handleOpeningVideoUpload = async (file: File | null) => {
-    if (!file || !canManage) return;
-
+    if (!file) return;
     setIsUploading(true);
-    setMessage('');
-
     try {
       const publicUrl = await uploadPortalAsset(file, 'opening');
       setOpeningVideoUrl(publicUrl);
       setMessage('Opening video uploaded. Click Save Changes to publish.');
-    } catch (error: unknown) {
-      const detail = error instanceof Error ? error.message : 'Unknown upload error';
-      setMessage(`Opening video upload failed. Check the portal-assets bucket. ${detail}`);
     } finally {
       setIsUploading(false);
     }
   };
 
-  if (loading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-black text-white">
-        Loading command center...
-      </div>
-    );
-  }
+  if (loading || !user) return <div className="flex min-h-screen items-center justify-center bg-black text-white">Loading command center...</div>;
 
   const tabStyle = (tab: AdminTab) => ({
-    padding: '0.5rem 1.25rem',
-    borderRadius: '999px',
-    border: 'none',
-    cursor: 'pointer',
-    fontSize: '0.82rem',
-    fontWeight: 600,
-    letterSpacing: '0.1em',
-    textTransform: 'uppercase' as const,
-    transition: 'all 0.2s ease',
-    background: activeTab === tab ? 'rgba(103,232,249,0.2)' : 'rgba(255,255,255,0.05)',
-    color: activeTab === tab ? '#67e8f9' : 'rgba(255,255,255,0.55)',
-    boxShadow: activeTab === tab ? '0 0 16px rgba(103,232,249,0.25)' : 'none',
+    padding: '0.5rem 1.25rem', borderRadius: '999px', border: 'none', cursor: 'pointer', fontSize: '0.82rem', fontWeight: 600,
+    letterSpacing: '0.1em', textTransform: 'uppercase' as const, background: activeTab === tab ? 'rgba(103,232,249,0.2)' : 'rgba(255,255,255,0.05)',
+    color: activeTab === tab ? '#67e8f9' : 'rgba(255,255,255,0.55)', boxShadow: activeTab === tab ? '0 0 16px rgba(103,232,249,0.25)' : 'none',
   });
 
   return (
     <div className="min-h-screen bg-[radial-gradient(circle_at_top,#18244f_0%,#03040a_45%,#000_100%)] p-6 text-white md:p-8">
       <div className="mx-auto max-w-6xl space-y-6">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-cyan-200/70">Occu-Med Secure Portal</p>
-            <h1 className="mt-2 text-3xl font-bold uppercase tracking-[0.18em] md:text-4xl">Admin Command Center</h1>
-            <p className="mt-2 text-sm text-white/55">
-              Invite users by email, assign portal access, and publish planet links from one central backend.
-            </p>
-          </div>
-          <Link href="/">
-            <Button variant="outline" className="border-white/20 bg-white/5 text-white hover:bg-white/10">
-              Return to Portal
-            </Button>
-          </Link>
+          <div><p className="text-xs font-semibold uppercase tracking-[0.32em] text-cyan-200/70">Occu-Med Secure Portal</p><h1 className="mt-2 text-3xl font-bold uppercase tracking-[0.18em] md:text-4xl">Admin Command Center</h1><p className="mt-2 text-sm text-white/55">Create portal users, assign planet access, and publish portal links from portal_settings storage.</p></div>
+          <div className="flex gap-2"><Link href="/"><Button variant="outline" className="border-white/20 bg-white/5 text-white hover:bg-white/10">Return to Portal</Button></Link><Button onClick={() => { logoutAdmin(); setLocation('/login?next=/admin'); }} variant="outline" className="border-white/20 bg-white/5 text-white hover:bg-white/10">Sign Out</Button></div>
         </div>
+        {message && <div className="rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-sm text-white/80 backdrop-blur-xl">{message}</div>}
+        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}><button style={tabStyle('users')} onClick={() => setActiveTab('users')}>User Management</button><button style={tabStyle('portals')} onClick={() => setActiveTab('portals')}>Planet Portals</button><button style={tabStyle('launch')} onClick={() => setActiveTab('launch')}>Launch Experience</button></div>
 
-        {!isLive && (
-          <Card className="border-amber-300/35 bg-amber-500/10 text-white backdrop-blur-xl">
-            <CardHeader>
-              <CardTitle>Setup Mode Active</CardTitle>
-              <CardDescription className="text-amber-100/75">
-                Add VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in Render, then create the portal_users and portal_settings tables in Supabase.
-              </CardDescription>
-            </CardHeader>
-          </Card>
-        )}
+        {activeTab === 'users' && <div className="space-y-6">
+          <Card className="border-white/10 bg-black/35 text-white backdrop-blur-xl"><CardHeader><CardTitle>Create User</CardTitle><CardDescription className="text-white/55">Enter a first and last name. Username is generated automatically and only a PIN digest is stored.</CardDescription></CardHeader><CardContent className="space-y-4">
+            <div className="grid gap-3 md:grid-cols-3"><input value={firstName} onChange={(e) => setFirstName(e.target.value)} placeholder="First Name" className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30" /><input value={lastName} onChange={(e) => setLastName(e.target.value)} placeholder="Last Name" className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30" /><Button onClick={addUser} disabled={!usernamePreview || saving} className="bg-white text-black hover:bg-cyan-100">{saving ? 'Working...' : 'Generate User + PIN'}</Button></div>
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-white/75">Username preview: <span className="font-mono text-cyan-100">{usernamePreview || 'firstnamelastname'}</span></div>
+            {generatedCode && <div className="rounded-2xl border border-cyan-200/30 bg-cyan-200/10 p-4"><p className="text-xs uppercase tracking-[0.18em] text-cyan-100/80">Generated access code</p><p className="mt-2 text-sm">Username: <span className="font-mono text-white">{generatedCode.username}</span></p><p className="text-sm">PIN/Password: <span className="font-mono text-2xl text-white">{generatedCode.code}</span></p><p className="mt-2 text-xs text-white/50">Copy this now. The plain text code is not saved.</p></div>}
+          </CardContent></Card>
 
-        {isLive && user && !isAdmin && (
-          <Card className="border-red-300/35 bg-red-500/10 text-white backdrop-blur-xl">
-            <CardHeader>
-              <CardTitle>Admin Access Required</CardTitle>
-              <CardDescription className="text-red-100/75">
-                This signed-in account does not have Admin role access in portal_users.
-              </CardDescription>
-            </CardHeader>
-          </Card>
-        )}
+          <Card className="border-white/10 bg-black/35 text-white backdrop-blur-xl"><CardHeader><CardTitle>User Permissions</CardTitle><CardDescription className="text-white/55">Toggle portal access for non-admin planets only, then save changes.</CardDescription></CardHeader><CardContent><div className="overflow-x-auto"><table style={{ width: '100%', borderCollapse: 'collapse', minWidth: '760px' }}><thead><tr style={{ background: 'rgba(255,255,255,0.06)' }}><th style={{ textAlign: 'left', padding: '0.75rem 1rem' }}>User</th>{USER_PORTALS.map((portal) => <th key={portal.id} style={{ padding: '0.75rem 0.25rem', textAlign: 'center', color: portal.glow }}>{portal.label}</th>)}<th>Actions</th></tr></thead><tbody>{users.map((managedUser) => <tr key={managedUser.id} style={{ borderTop: '1px solid rgba(255,255,255,0.07)' }}><td style={{ padding: '0.75rem 1rem' }}><div>{managedUser.firstName} {managedUser.lastName}</div><div className="font-mono text-xs text-cyan-100/75">{managedUser.username}</div></td>{USER_PORTALS.map((portal) => { const checked = managedUser.permissions.includes(portal.permissionKey); return <td key={portal.id} style={{ padding: '0.75rem 0.25rem', textAlign: 'center' }}><button onClick={() => togglePermission(managedUser.id, portal.permissionKey)} style={{ width: '36px', height: '20px', borderRadius: '999px', border: checked ? `1px solid ${portal.glow}88` : '1px solid rgba(255,255,255,0.15)', background: checked ? `${portal.glow}44` : 'rgba(255,255,255,0.05)', boxShadow: checked ? `0 0 10px ${portal.glow}55` : 'none' }} aria-label={`${managedUser.username} ${portal.label} access`} /></td>; })}<td style={{ textAlign: 'center' }}><div className="flex justify-center gap-2"><button onClick={() => void regenerateCode(managedUser.id)} className="rounded-md border border-cyan-200/30 bg-cyan-200/10 px-2 py-1 text-xs text-cyan-100">Regenerate PIN</button><button onClick={() => void removeUser(managedUser.id)} className="rounded-md border border-red-300/30 bg-red-500/10 px-2 py-1 text-xs text-red-200">Remove</button></div></td></tr>)}</tbody></table></div><div className="mt-4 flex justify-end"><Button onClick={saveChanges} disabled={saving || isUploading} className="bg-white text-black hover:bg-cyan-100">{saving ? 'Saving...' : 'Save Changes'}</Button></div></CardContent></Card>
+        </div>}
 
-        {message && (
-          <div className="rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-sm text-white/80 backdrop-blur-xl">
-            {message}
-          </div>
-        )}
+        {activeTab === 'portals' && <Card className="border-white/10 bg-black/35 text-white backdrop-blur-xl"><CardHeader><CardTitle>Planet Portal Configuration</CardTitle><CardDescription className="text-white/55">Portal URLs and transition videos are preserved in portal_settings.data.settings.</CardDescription></CardHeader><CardContent className="space-y-4"><div className="grid gap-4 md:grid-cols-2">{USER_PORTALS.map((portal) => <div key={portal.id} className="rounded-2xl border border-white/10 bg-white/5 p-4"><div className="mb-3 text-sm font-bold uppercase tracking-[0.18em]" style={{ color: portal.glow }}>{portal.label}</div><label className="mb-2 block text-xs text-white/40">Render URL</label><input type="url" value={draftSettings[portal.id].url} onChange={(event) => setDraftSettings((current) => ({ ...current, [portal.id]: { ...current[portal.id], url: event.target.value } }))} placeholder="https://your-render-service.onrender.com" className="mb-3 w-full rounded-xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30" /><label className="mb-2 block text-xs text-white/40">Transition Video URL</label><input type="url" value={draftSettings[portal.id].videoUrl} onChange={(event) => setDraftSettings((current) => ({ ...current, [portal.id]: { ...current[portal.id], videoUrl: event.target.value } }))} placeholder="https://.../transition.mp4" className="mb-3 w-full rounded-xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30" /><input type="file" accept="video/*" onChange={(event) => void handleVideoUpload(portal.id, event.target.files?.[0] ?? null)} disabled={isUploading} className="text-xs text-white/60" /></div>)}</div><div className="flex justify-end"><Button onClick={saveChanges} disabled={saving || isUploading} className="bg-white text-black hover:bg-cyan-100">{saving ? 'Saving...' : isUploading ? 'Uploading...' : 'Save Portal Links'}</Button></div></CardContent></Card>}
 
-        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
-          <button style={tabStyle('users')} onClick={() => setActiveTab('users')}>User Management</button>
-          <button style={tabStyle('portals')} onClick={() => setActiveTab('portals')}>Planet Portals</button>
-          <button style={tabStyle('launch')} onClick={() => setActiveTab('launch')}>Launch Experience</button>
-        </div>
-
-        {activeTab === 'users' && (
-          <div className="space-y-6">
-            <Card className="border-white/10 bg-black/35 text-white backdrop-blur-xl">
-              <CardHeader>
-                <CardTitle>Invite User</CardTitle>
-                <CardDescription className="text-white/55">
-                  Enter the person’s email, select the exact portals they should access, then send the invite.
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="flex flex-col gap-3 md:flex-row">
-                  <input
-                    value={inviteEmail}
-                    onChange={(event) => setInviteEmail(event.target.value)}
-                    onKeyDown={(event) => event.key === 'Enter' && inviteUser()}
-                    placeholder="name@occu-med.com"
-                    className="min-w-0 flex-1 rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30 focus:border-cyan-200/50"
-                  />
-                  <Button onClick={inviteUser} disabled={!canManage || saving} className="bg-white text-black hover:bg-cyan-100">
-                    {saving ? 'Working...' : 'Send Invite'}
-                  </Button>
-                </div>
-
-                <div className="mt-4 rounded-2xl border border-white/10 bg-white/5 p-4">
-                  <div className="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-                    <div>
-                      <p className="text-xs font-bold uppercase tracking-[0.18em] text-cyan-100/80">Portal Access</p>
-                      <p className="text-xs text-white/45">Selected access is saved before the invite email is sent.</p>
-                    </div>
-                    <div className="flex gap-2">
-                      <button
-                        type="button"
-                        onClick={() => setInvitePermissions(INVITABLE_PORTALS.map((portal) => portal.permissionKey))}
-                        className="rounded-full border border-cyan-200/25 bg-cyan-200/10 px-3 py-1 text-xs text-cyan-100"
-                      >
-                        Select All
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setInvitePermissions([])}
-                        className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-white/60"
-                      >
-                        Clear
-                      </button>
-                    </div>
-                  </div>
-
-                  <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-                    {INVITABLE_PORTALS.map((portal) => {
-                      const selected = invitePermissions.includes(portal.permissionKey);
-                      return (
-                        <button
-                          key={portal.id}
-                          type="button"
-                          onClick={() => toggleInvitePermission(portal.permissionKey)}
-                          className="rounded-xl border px-3 py-2 text-left text-sm transition"
-                          style={{
-                            borderColor: selected ? `${portal.glow}aa` : 'rgba(255,255,255,0.12)',
-                            background: selected ? `${portal.glow}24` : 'rgba(255,255,255,0.04)',
-                            color: selected ? '#fff' : 'rgba(255,255,255,0.62)',
-                            boxShadow: selected ? `0 0 18px ${portal.glow}33` : 'none',
-                          }}
-                        >
-                          {portal.label}
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card className="border-white/10 bg-black/35 text-white backdrop-blur-xl">
-              <CardHeader>
-                <CardTitle>User Permissions</CardTitle>
-                <CardDescription className="text-white/55">
-                  These permissions determine which planets each signed-in user can open.
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="overflow-x-auto">
-                  <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: '760px' }}>
-                    <thead>
-                      <tr style={{ background: 'rgba(255,255,255,0.06)' }}>
-                        <th style={{ textAlign: 'left', padding: '0.75rem 1rem', fontSize: '0.7rem', fontWeight: 700, letterSpacing: '0.15em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.5)' }}>User</th>
-                        <th style={{ padding: '0.75rem 0.5rem', fontSize: '0.7rem', fontWeight: 700, letterSpacing: '0.15em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.5)' }}>Role</th>
-                        {INVITABLE_PORTALS.map((portal) => (
-                          <th key={portal.id} style={{ padding: '0.75rem 0.25rem', fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', textAlign: 'center', color: portal.glow }}>
-                            {portal.label}
-                          </th>
-                        ))}
-                        <th style={{ padding: '0.75rem 0.5rem', fontSize: '0.7rem', color: 'rgba(255,255,255,0.3)' }}>Actions</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {users.map((managedUser) => (
-                        <tr key={managedUser.email} style={{ borderTop: '1px solid rgba(255,255,255,0.07)' }}>
-                          <td style={{ padding: '0.75rem 1rem', fontSize: '0.85rem', color: 'rgba(255,255,255,0.85)', maxWidth: '220px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                            {managedUser.email}
-                          </td>
-                          <td style={{ padding: '0.75rem 0.5rem', textAlign: 'center' }}>
-                            <button
-                              onClick={() => toggleRole(managedUser.email)}
-                              disabled={!canManage}
-                              style={{ borderRadius: '999px', border: '1px solid rgba(255,255,255,0.2)', background: managedUser.role === 'Admin' ? 'rgba(103,232,249,0.15)' : 'rgba(255,255,255,0.05)', color: managedUser.role === 'Admin' ? '#67e8f9' : 'rgba(255,255,255,0.6)', padding: '0.2rem 0.6rem', fontSize: '0.7rem', fontWeight: 600, cursor: 'pointer' }}
-                            >
-                              {managedUser.role}
-                            </button>
-                          </td>
-                          {INVITABLE_PORTALS.map((portal) => {
-                            const checked = managedUser.permissions.includes(portal.permissionKey);
-                            return (
-                              <td key={portal.id} style={{ padding: '0.75rem 0.25rem', textAlign: 'center' }}>
-                                <button
-                                  onClick={() => togglePermission(managedUser.email, portal.permissionKey)}
-                                  disabled={!canManage}
-                                  style={{ width: '36px', height: '20px', borderRadius: '999px', border: checked ? `1px solid ${portal.glow}88` : '1px solid rgba(255,255,255,0.15)', background: checked ? `${portal.glow}44` : 'rgba(255,255,255,0.05)', boxShadow: checked ? `0 0 10px ${portal.glow}55` : 'none', cursor: 'pointer', transition: 'all 0.2s ease', display: 'block', margin: '0 auto' }}
-                                  aria-label={`${managedUser.email} ${portal.label} access`}
-                                />
-                              </td>
-                            );
-                          })}
-                          <td style={{ padding: '0.75rem 0.5rem', textAlign: 'center' }}>
-                            <div style={{ display: 'flex', gap: '0.3rem', justifyContent: 'center' }}>
-                              <button onClick={() => grantAll(managedUser.email)} disabled={!canManage} style={{ background: 'rgba(103,232,249,0.1)', border: '1px solid rgba(103,232,249,0.3)', color: '#67e8f9', borderRadius: '6px', padding: '0.2rem 0.4rem', fontSize: '0.65rem', cursor: 'pointer' }}>All</button>
-                              <button onClick={() => revokeAll(managedUser.email)} disabled={!canManage} style={{ background: 'rgba(255,100,100,0.1)', border: '1px solid rgba(255,100,100,0.3)', color: '#f87171', borderRadius: '6px', padding: '0.2rem 0.4rem', fontSize: '0.65rem', cursor: 'pointer' }}>None</button>
-                              <button onClick={() => void removeUser(managedUser.email)} disabled={!canManage} style={{ background: 'rgba(255,100,100,0.08)', border: '1px solid rgba(255,100,100,0.2)', color: 'rgba(248,113,113,0.7)', borderRadius: '6px', padding: '0.2rem 0.4rem', fontSize: '0.65rem', cursor: 'pointer' }}>Remove</button>
-                            </div>
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-
-                <div className="mt-4 flex justify-end">
-                  <Button onClick={saveChanges} disabled={saving || isUploading || !canManage} className="bg-white text-black hover:bg-cyan-100">
-                    {saving ? 'Saving...' : 'Save Changes'}
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        )}
-
-        {activeTab === 'portals' && (
-          <Card className="border-white/10 bg-black/35 text-white backdrop-blur-xl">
-            <CardHeader>
-              <CardTitle>Planet Portal Configuration</CardTitle>
-              <CardDescription className="text-white/55">
-                These Render URLs are saved centrally in Supabase and loaded by every signed-in user.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid gap-4 md:grid-cols-2">
-                {INVITABLE_PORTALS.map((portal) => (
-                  <div key={portal.id} className="rounded-2xl border border-white/10 bg-white/5 p-4">
-                    <div className="mb-3 text-sm font-bold uppercase tracking-[0.18em]" style={{ color: portal.glow }}>
-                      {portal.label}
-                    </div>
-                    <label className="mb-2 block text-xs text-white/40">Render URL</label>
-                    <input
-                      type="url"
-                      value={draftSettings[portal.id].url}
-                      onChange={(event) => setDraftSettings((current) => ({ ...current, [portal.id]: { ...current[portal.id], url: event.target.value } }))}
-                      placeholder="https://your-render-service.onrender.com"
-                      className="mb-3 w-full rounded-xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30 focus:border-cyan-200/50"
-                    />
-                    <label className="mb-2 block text-xs text-white/40">Transition Video URL</label>
-                    <input
-                      type="url"
-                      value={draftSettings[portal.id].videoUrl}
-                      onChange={(event) => setDraftSettings((current) => ({ ...current, [portal.id]: { ...current[portal.id], videoUrl: event.target.value } }))}
-                      placeholder="https://.../transition.mp4"
-                      className="mb-3 w-full rounded-xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30 focus:border-cyan-200/50"
-                    />
-                    <input
-                      type="file"
-                      accept="video/*"
-                      onChange={(event) => void handleVideoUpload(portal.id, event.target.files?.[0] ?? null)}
-                      disabled={isUploading || !canManage}
-                      className="text-xs text-white/60"
-                    />
-                  </div>
-                ))}
-              </div>
-              <div className="flex justify-end">
-                <Button onClick={saveChanges} disabled={saving || isUploading || !canManage} className="bg-white text-black hover:bg-cyan-100">
-                  {saving ? 'Saving...' : isUploading ? 'Uploading...' : 'Save Portal Links'}
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        )}
-
-        {activeTab === 'launch' && (
-          <div className="space-y-6">
-            <Card className="border-white/10 bg-black/35 text-white backdrop-blur-xl">
-              <CardHeader>
-                <CardTitle>Opening Theme Video</CardTitle>
-                <CardDescription className="text-white/55">
-                  This is saved centrally and used by the portal opening experience.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <input
-                  value={openingVideoUrl}
-                  onChange={(event) => setOpeningVideoUrl(event.target.value)}
-                  placeholder="https://.../opening-theme.mp4"
-                  className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30 focus:border-cyan-200/50"
-                />
-                <input
-                  type="file"
-                  accept="video/*"
-                  onChange={(event) => void handleOpeningVideoUpload(event.target.files?.[0] ?? null)}
-                  disabled={isUploading || !canManage}
-                  className="text-xs text-white/60"
-                />
-              </CardContent>
-            </Card>
-
-            <Card className="border-white/10 bg-black/35 text-white backdrop-blur-xl">
-              <CardHeader>
-                <CardTitle>Startup Audio</CardTitle>
-                <CardDescription className="text-white/55">
-                  Optional ambient audio that plays during portal transitions.
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <input
-                  value={audioUrl}
-                  onChange={(event) => setAudioUrl(event.target.value)}
-                  placeholder="https://.../startup.mp3"
-                  className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30 focus:border-cyan-200/50"
-                />
-              </CardContent>
-            </Card>
-
-            <Button onClick={saveChanges} disabled={saving || isUploading || !canManage} className="w-full bg-white text-black hover:bg-cyan-100">
-              {saving ? 'Saving...' : isUploading ? 'Uploading...' : 'Save Launch Settings'}
-            </Button>
-          </div>
-        )}
+        {activeTab === 'launch' && <div className="space-y-6"><Card className="border-white/10 bg-black/35 text-white backdrop-blur-xl"><CardHeader><CardTitle>Opening Theme Video</CardTitle><CardDescription className="text-white/55">This is saved centrally and used by the portal opening experience.</CardDescription></CardHeader><CardContent className="space-y-4"><input value={openingVideoUrl} onChange={(event) => setOpeningVideoUrl(event.target.value)} placeholder="https://.../opening-theme.mp4" className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30" /><input type="file" accept="video/*" onChange={(event) => void handleOpeningVideoUpload(event.target.files?.[0] ?? null)} disabled={isUploading} className="text-xs text-white/60" /></CardContent></Card><Card className="border-white/10 bg-black/35 text-white backdrop-blur-xl"><CardHeader><CardTitle>Startup Audio</CardTitle><CardDescription className="text-white/55">Optional ambient audio that plays during portal transitions.</CardDescription></CardHeader><CardContent><input value={audioUrl} onChange={(event) => setAudioUrl(event.target.value)} placeholder="https://.../startup.mp3" className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30" /></CardContent></Card><Button onClick={saveChanges} disabled={saving || isUploading} className="w-full bg-white text-black hover:bg-cyan-100">{saving ? 'Saving...' : isUploading ? 'Uploading...' : 'Save Launch Settings'}</Button></div>}
       </div>
     </div>
   );

--- a/occu-med-portal/src/pages/Login.tsx
+++ b/occu-med-portal/src/pages/Login.tsx
@@ -4,155 +4,61 @@ import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter }
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
 import { useEffect, useState } from 'react';
-import { supabase } from '../lib/supabase';
 
 function getNextPath(): string {
-  if (typeof window === 'undefined') return '/';
+  if (typeof window === 'undefined') return '/admin';
   const params = new URLSearchParams(window.location.search);
   const next = params.get('next');
-  return next?.startsWith('/') ? next : '/';
-}
-
-function formatAuthError(error: { message?: string; status?: number; name?: string }) {
-  const details = [
-    error.message,
-    error.status ? `Status: ${error.status}` : '',
-    error.name ? `Name: ${error.name}` : '',
-  ].filter(Boolean).join(' | ');
-
-  if (error.status === 500 && /magic link|email|smtp|send/i.test(details)) {
-    return `${details}. Supabase Auth could not send the email. Check Supabase Auth custom SMTP settings for the connected domain mailbox.`;
-  }
-
-  return details;
+  return next?.startsWith('/') ? next : '/admin';
 }
 
 export default function Login() {
-  const { isLive, user } = useAuth();
+  const { user, loginAdmin } = useAuth();
   const [, setLocation] = useLocation();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState('');
-  const [mode, setMode] = useState<'magic' | 'password'>('magic');
 
   useEffect(() => {
-    if (!isLive) {
-      setLocation('/');
-    } else if (user) {
-      setLocation(getNextPath());
-    }
-  }, [isLive, user, setLocation]);
+    if (user) setLocation(getNextPath());
+  }, [user, setLocation]);
 
-  if (!isLive || user) {
-    return null;
-  }
-
-  const sendMagicLink = async (event: React.FormEvent) => {
+  const handleAdminLogin = (event: React.FormEvent) => {
     event.preventDefault();
-    if (!supabase) return;
-
     setLoading(true);
     setMessage('');
 
-    const { error } = await supabase.auth.signInWithOtp({
-      email: email.trim().toLowerCase(),
-      options: {
-        shouldCreateUser: true,
-        emailRedirectTo: `${window.location.origin}/setup-account`,
-      },
-    });
-
-    if (error) {
-      console.error('Magic link error:', error);
-      setMessage(formatAuthError(error));
-    } else {
-      setMessage('Check your email for the secure sign-in link.');
-    }
-
-    setLoading(false);
-  };
-
-  const handlePasswordLogin = async (event: React.FormEvent) => {
-    event.preventDefault();
-    if (!supabase) return;
-
-    setLoading(true);
-    setMessage('');
-
-    const { error } = await supabase.auth.signInWithPassword({
-      email: email.trim().toLowerCase(),
-      password,
-    });
-
-    if (error) {
-      console.error('Password login error:', error);
-      setMessage(formatAuthError(error));
-    } else {
+    if (loginAdmin(email, password, true)) {
       setLocation(getNextPath());
+      return;
     }
 
+    setMessage('Invalid admin email or password.');
     setLoading(false);
   };
+
+  if (user) return null;
 
   return (
     <div className="min-h-screen bg-black flex items-center justify-center p-4">
       <Card className="w-full max-w-md bg-black/60 border-white/10 backdrop-blur-xl">
         <CardHeader className="space-y-2">
           <div className="text-2xl font-bold tracking-widest text-center text-white glow-text uppercase mb-4">OCCU-MED</div>
-          <CardTitle className="text-center text-xl text-white">Secure Access</CardTitle>
+          <CardTitle className="text-center text-xl text-white">Admin Login</CardTitle>
           <CardDescription className="text-center text-white/60">
-            Enter your email to receive a secure portal sign-in link.
+            Enter the preconfigured Render admin credentials to open the command center.
           </CardDescription>
         </CardHeader>
-        <form onSubmit={mode === 'magic' ? sendMagicLink : handlePasswordLogin}>
+        <form onSubmit={handleAdminLogin}>
           <CardContent className="space-y-4">
-            <div className="grid grid-cols-2 gap-2 rounded-xl border border-white/10 bg-white/5 p-1">
-              <button
-                type="button"
-                onClick={() => setMode('magic')}
-                className={`rounded-lg px-3 py-2 text-xs font-semibold ${mode === 'magic' ? 'bg-white text-black' : 'text-white/60'}`}
-              >
-                Email Link
-              </button>
-              <button
-                type="button"
-                onClick={() => setMode('password')}
-                className={`rounded-lg px-3 py-2 text-xs font-semibold ${mode === 'password' ? 'bg-white text-black' : 'text-white/60'}`}
-              >
-                Password
-              </button>
-            </div>
-
-            <Input
-              type="email"
-              placeholder="Email Address"
-              value={email}
-              onChange={(event) => setEmail(event.target.value)}
-              className="bg-white/5 border-white/10 text-white placeholder:text-white/40 focus:border-white/30"
-              required
-            />
-
-            {mode === 'password' && (
-              <Input
-                type="password"
-                placeholder="Password"
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-                className="bg-white/5 border-white/10 text-white placeholder:text-white/40 focus:border-white/30"
-                required
-              />
-            )}
-
-            {message && (
-              <div className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/75">
-                {message}
-              </div>
-            )}
+            <Input type="email" placeholder="Admin Email" value={email} onChange={(event) => setEmail(event.target.value)} className="bg-white/5 border-white/10 text-white placeholder:text-white/40 focus:border-white/30" required />
+            <Input type="password" placeholder="Admin Password" value={password} onChange={(event) => setPassword(event.target.value)} className="bg-white/5 border-white/10 text-white placeholder:text-white/40 focus:border-white/30" required />
+            {message && <div className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/75">{message}</div>}
           </CardContent>
           <CardFooter>
             <Button type="submit" className="w-full bg-white text-black hover:bg-white/90" disabled={loading}>
-              {loading ? 'Authenticating...' : mode === 'magic' ? 'Send Secure Link' : 'Sign In'}
+              {loading ? 'Opening...' : 'Open Admin Panel'}
             </Button>
           </CardFooter>
         </form>

--- a/occu-med-portal/src/pages/SetupAccount.tsx
+++ b/occu-med-portal/src/pages/SetupAccount.tsx
@@ -1,75 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useLocation } from 'wouter';
-import { Card, CardHeader, CardTitle, CardDescription, CardFooter } from '../components/ui/card';
-import { Button } from '../components/ui/button';
-import { useAuth } from '../hooks/useAuth';
 
 export default function SetupAccount() {
-  const { user, loading, isLive } = useAuth();
   const [, setLocation] = useLocation();
-  const [message, setMessage] = useState('Finishing your secure portal setup...');
 
   useEffect(() => {
-    if (loading) return;
+    setLocation('/');
+  }, [setLocation]);
 
-    if (!isLive) {
-      setMessage('Supabase is not configured yet, so account setup cannot be completed.');
-      return;
-    }
-
-    if (!user) {
-      setMessage('Open the secure invite link from your email to finish account setup.');
-      return;
-    }
-
-    setMessage('Account setup complete. Redirecting you to the portal...');
-    const timer = window.setTimeout(() => setLocation('/'), 1400);
-    return () => window.clearTimeout(timer);
-  }, [isLive, loading, setLocation, user]);
-
-  return (
-    <div className="relative min-h-screen overflow-hidden bg-[#020617] text-white">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(103,232,249,0.22),transparent_30%),radial-gradient(circle_at_80%_30%,rgba(168,85,247,0.24),transparent_34%),radial-gradient(circle_at_50%_90%,rgba(59,130,246,0.22),transparent_38%)]" />
-      <div className="absolute left-1/2 top-1/2 h-[42rem] w-[42rem] -translate-x-1/2 -translate-y-1/2 rounded-full border border-cyan-200/10 shadow-[0_0_90px_rgba(103,232,249,0.12)]" />
-      <div className="absolute left-1/2 top-1/2 h-[28rem] w-[28rem] -translate-x-1/2 -translate-y-1/2 rounded-full border border-violet-200/10" />
-      <div className="absolute inset-0 bg-[linear-gradient(rgba(255,255,255,0.025)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.025)_1px,transparent_1px)] bg-[size:56px_56px] opacity-30" />
-
-      <main className="relative z-10 flex min-h-screen items-center justify-center p-6">
-        <Card className="w-full max-w-xl overflow-hidden border-white/15 bg-black/35 text-white shadow-[0_30px_120px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
-          <div className="h-1 w-full bg-gradient-to-r from-cyan-300 via-blue-400 to-violet-400" />
-          <CardHeader className="space-y-6 p-8 text-center">
-            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl border border-cyan-200/25 bg-cyan-200/10 text-3xl shadow-[0_0_40px_rgba(103,232,249,0.22)]">
-              {user ? '✓' : '◎'}
-            </div>
-
-            <div>
-              <div className="mb-3 text-sm font-bold uppercase tracking-[0.45em] text-cyan-100/80">Occu-Med</div>
-              <CardTitle className="text-3xl font-black uppercase tracking-[0.18em] text-white">
-                Account Setup
-              </CardTitle>
-              <CardDescription className="mx-auto mt-4 max-w-md text-base leading-7 text-white/65">
-                {message}
-              </CardDescription>
-            </div>
-
-            {user && (
-              <div className="mx-auto flex w-full max-w-sm items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/75">
-                <span className="text-cyan-200">✦</span>
-                <span className="truncate">Signed in as {user.email}</span>
-              </div>
-            )}
-          </CardHeader>
-
-          <CardFooter className="flex flex-col gap-3 px-8 pb-8">
-            <Button onClick={() => setLocation(user ? '/' : '/login')} className="group w-full bg-white text-black hover:bg-cyan-100">
-              {user ? 'Enter Portal' : 'Go to Login'} <span className="ml-2 transition group-hover:translate-x-1">→</span>
-            </Button>
-            <p className="text-center text-xs leading-5 text-white/35">
-              Access is controlled by your assigned portal permissions. Contact an admin if a planet is visible but does not open for your account.
-            </p>
-          </CardFooter>
-        </Card>
-      </main>
-    </div>
-  );
+  return <div className="flex min-h-screen items-center justify-center bg-black text-white">Redirecting to portal...</div>;
 }


### PR DESCRIPTION
### Motivation
- Replace the Supabase Auth / email-invite flow with a simple admin-controlled access model using preconfigured admin credentials and a local admin session.
- Provide an admin UI for creating/manage portal users (username + generated PIN) and persist those users alongside existing portal link/video settings.
- Enforce per-portal access for public portal launches via username + PIN validation without magic links, SMTP, passkeys, or Supabase Auth calls.

### Description
- Replaced the auth layer with a frontend admin-session hook that checks `VITE_ADMIN_EMAIL` and `VITE_ADMIN_PASSWORD`, stores an admin session in browser storage, and exposes `loginAdmin`/`logoutAdmin` via `useAuth` (no Supabase auth calls). (src/hooks/useAuth.tsx)
- Simplified `/login` to an admin-only form (Admin Email, Admin Password, Open Admin Panel) and removed the email link/password tab logic. (src/pages/Login.tsx)
- Added `accessControl.ts` helpers for username normalization, username generation, secure PIN generation, SHA-256 digesting, and user id creation. (src/lib/accessControl.ts)
- Extended the portal backend state to include a `users` array and mapped the existing `portal_settings.data` shape to persist `settings`, `openingVideoUrl`, `audioUrl`, and `users` via the existing `loadPortalState`/`savePortalState` functions. (src/lib/portalBackend.ts)
- Reworked the Admin Command Center: admins can create users by first/last name (username auto-generated), immediately see a generated PIN (plain text shown once), store only the SHA-256 PIN digest, regenerate PINs, remove users, and toggle per-portal access for non-admin portals; portal URL/video upload and save remain intact. (src/pages/Admin.tsx)
- Updated the public portal map so clicking a non-admin planet opens a username + PIN modal; the entered PIN is hashed and compared to the stored digest, and access is granted only if the user exists and has the portal permission, preserving the existing transition-video and audio launch behavior. The Admin planet still routes to `/admin` and requires the admin session. (src/components/PortalMap.tsx)
- Removed invite / magic-link / Supabase-auth UI flows and redirected the legacy setup-account route to the portal (no email invite flow remains). (src/pages/SetupAccount.tsx)
- Kept existing portal URL, transition video, opening video, audio, artwork, planet layout, and transition/launch UX unchanged while adding the new access checks and storage shape.

### Testing
- Ran the portal production build with `pnpm --filter @workspace/occu-med-portal run build` and the build completed successfully (Vite build output produced dist files).
- Ran TypeScript checks with `pnpm --filter @workspace/occu-med-portal run typecheck` and there were no type errors reported.
- Basic runtime verification: admin login flow, user creation (username generation + PIN shown), PIN regeneration, permission toggles, user deletion, saving to `portal_settings.data`, and portal launch behavior behind username/PIN were exercised during development and function as described.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cd3e649348326b12f63f5c1785945)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin login experience with redirected access to the admin area.
  * Introduced a new portal access flow using username and PIN/password verification.
  * Updated admin tools to create, regenerate, and remove portal users, plus manage portal permissions.

* **Bug Fixes**
  * Improved access handling so users now see a clear “not configured” message when portal setup is incomplete.
  * Simplified redirects for unauthenticated or non-admin access paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->